### PR TITLE
Fix score output formatting

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBacBuoc.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBacBuoc.cs
@@ -17,7 +17,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         }
         public virtual void InDiem()
         {
-            Console.WriteLine($"Toán: +{Toan} +| Văn: {Van} | Anh: {Anh}");
+            Console.WriteLine($"Toán: {Toan} | Văn: {Van} | Anh: {Anh}");
         }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiB.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiB.cs
@@ -53,7 +53,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             Console.WriteLine("=== Thí sinh khối B ===");
             base.InThongTin();
             Diem.InDiem();
-            Console.WriteLine($"Tổng điểm khối A:{TongDiem()}");
+            Console.WriteLine($"Tổng điểm khối B: {TongDiem()}");
         }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiC.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiC.cs
@@ -53,7 +53,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             Console.WriteLine("=== Thí sinh khối C ===");
             base.InThongTin();
             Diem.InDiem();
-            Console.WriteLine($"Tổng điểm khối A:{TongDiem()}");
+            Console.WriteLine($"Tổng điểm khối C: {TongDiem()}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove stray characters from the compulsory subject score output so the three subjects display cleanly
- show the correct total score labels for candidates in blocks B and C

## Testing
- `dotnet build "Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.sln"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d56e39cb4483229dd6dd807a9d760e