### PR TITLE
Set C# language version

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.csproj
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học</RootNamespace>
     <AssemblyName>Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <LangVersion>8.0</LangVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>


### PR DESCRIPTION
## Summary
- set the project to use C# language version 8.0 to support switch expressions

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ef2a0d08832298c2722b1c7db80e