### PR TITLE
Switch candidate persistence from Excel to text

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.csproj
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.csproj
@@ -44,9 +44,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.102.2" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="%28Diem%29DiemThiBacBuoc.cs" />
     <Compile Include="%28Diem%29DiemThiKHTN.cs" />
     <Compile Include="%28Diem%29DiemThiKHXH.cs" />

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
@@ -10,13 +10,13 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             Console.OutputEncoding = Encoding.UTF8;
             Console.InputEncoding = Encoding.UTF8;
             const string dataDirectory = "Data";
-            const string dataFileName = "ThiSinh.xlsx";
+            const string dataFileName = "ThiSinh.txt";
             string filePath = Path.Combine(dataDirectory, dataFileName);
 
             Directory.CreateDirectory(dataDirectory);
 
             QuanLyThiSinh ql = new QuanLyThiSinh();
-            ql.TaiTuExcel(filePath);
+            ql.TaiTuTxt(filePath);
             ThiSinhKhoiA tsA = new ThiSinhKhoiA();
             tsA.Nhap();
             if (!ql.ThemThiSinh(tsA))
@@ -25,7 +25,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             }
             else
             {
-                ql.LuuVaoExcel(filePath);
+                ql.LuuVaoTxt(filePath);
             }
             ThiSinhKhoiC tsC = new ThiSinhKhoiC();
             tsC.Nhap();
@@ -35,7 +35,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             }
             else
             {
-                ql.LuuVaoExcel(filePath);
+                ql.LuuVaoTxt(filePath);
             }
             ql.InDanhSach();
             ql.ThongKeTheoKhoi();
@@ -51,7 +51,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                 Console.WriteLine();
             }
 
-            ql.LuuVaoExcel(filePath);
+            ql.LuuVaoTxt(filePath);
 
         }
     }


### PR DESCRIPTION
## Summary
- replace Excel import/export with UTF-8 text file handling in `QuanLyThiSinh`
- update the console program to read and write `ThiSinh.txt`
- drop the ClosedXML dependency from the project file

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7c525481c8322b503b0e585c04ca5