### PR TITLE
Add interactive menu for candidate management

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
@@ -17,42 +18,155 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
             QuanLyThiSinh ql = new QuanLyThiSinh();
             ql.TaiTuTxt(filePath);
-            ThiSinhKhoiA tsA = new ThiSinhKhoiA();
-            tsA.Nhap();
-            if (!ql.ThemThiSinh(tsA))
-            {
-                Console.WriteLine("Số báo danh đã tồn tại, không thể thêm thí sinh khối A.");
-            }
-            else
-            {
-                ql.LuuVaoTxt(filePath);
-            }
-            ThiSinhKhoiC tsC = new ThiSinhKhoiC();
-            tsC.Nhap();
-            if (!ql.ThemThiSinh(tsC))
-            {
-                Console.WriteLine("Số báo danh đã tồn tại, không thể thêm thí sinh khối C.");
-            }
-            else
-            {
-                ql.LuuVaoTxt(filePath);
-            }
-            ql.InDanhSach();
-            ql.ThongKeTheoKhoi();
-            ql.TimThuKhoa();
 
+            bool thoat = false;
+            while (!thoat)
+            {
+                HienThiMenu();
+                Console.Write("Chọn chức năng: ");
+                string luaChon = Console.ReadLine();
+                Console.WriteLine();
+
+                switch (luaChon)
+                {
+                    case "1":
+                        ThemThiSinhKhoiA(ql, filePath);
+                        break;
+                    case "2":
+                        ThemThiSinhKhoiB(ql, filePath);
+                        break;
+                    case "3":
+                        ThemThiSinhKhoiC(ql, filePath);
+                        break;
+                    case "4":
+                        ql.InDanhSach();
+                        break;
+                    case "5":
+                        ql.ThongKeTheoKhoi();
+                        break;
+                    case "6":
+                        ql.TimThuKhoa();
+                        break;
+                    case "7":
+                        TimKiemTheoHoTen(ql);
+                        break;
+                    case "8":
+                        ql.TaiTuTxt(filePath);
+                        break;
+                    case "9":
+                        ql.LuuVaoTxt(filePath);
+                        break;
+                    case "0":
+                        thoat = true;
+                        break;
+                    default:
+                        Console.WriteLine("Lựa chọn không hợp lệ. Vui lòng thử lại.");
+                        break;
+                }
+
+                Console.WriteLine();
+            }
+        }
+
+        private static void HienThiMenu()
+        {
+            Console.WriteLine("===== CHƯƠNG TRÌNH QUẢN LÝ THÍ SINH =====");
+            Console.WriteLine("1. Thêm thí sinh khối A");
+            Console.WriteLine("2. Thêm thí sinh khối B");
+            Console.WriteLine("3. Thêm thí sinh khối C");
+            Console.WriteLine("4. Hiển thị danh sách thí sinh");
+            Console.WriteLine("5. Thống kê số lượng theo khối");
+            Console.WriteLine("6. Tìm thủ khoa từng khối");
+            Console.WriteLine("7. Tìm kiếm thí sinh theo họ tên");
+            Console.WriteLine("8. Tải dữ liệu từ tệp");
+            Console.WriteLine("9. Lưu dữ liệu ra tệp");
+            Console.WriteLine("0. Thoát");
+        }
+
+        private static void ThemThiSinhKhoiA(QuanLyThiSinh ql, string filePath)
+        {
+            ThiSinhKhoiA thiSinh = NhapThiSinhKhoiA();
+            ThemThiSinh(ql, filePath, thiSinh);
+        }
+
+        private static void ThemThiSinhKhoiB(QuanLyThiSinh ql, string filePath)
+        {
+            ThiSinhKhoiB thiSinh = NhapThiSinhKhoiB();
+            ThemThiSinh(ql, filePath, thiSinh);
+        }
+
+        private static void ThemThiSinhKhoiC(QuanLyThiSinh ql, string filePath)
+        {
+            ThiSinhKhoiC thiSinh = NhapThiSinhKhoiC();
+            ThemThiSinh(ql, filePath, thiSinh);
+        }
+
+        private static ThiSinhKhoiA NhapThiSinhKhoiA()
+        {
+            ThiSinhKhoiA thiSinh = new ThiSinhKhoiA();
+            thiSinh.Nhap();
+            return thiSinh;
+        }
+
+        private static ThiSinhKhoiB NhapThiSinhKhoiB()
+        {
+            ThiSinhKhoiB thiSinh = new ThiSinhKhoiB();
+            thiSinh.Nhap();
+            return thiSinh;
+        }
+
+        private static ThiSinhKhoiC NhapThiSinhKhoiC()
+        {
+            ThiSinhKhoiC thiSinh = new ThiSinhKhoiC();
+            thiSinh.Nhap();
+            return thiSinh;
+        }
+
+        private static void ThemThiSinh(QuanLyThiSinh ql, string filePath, ThongTinThiSinh thiSinh)
+        {
+            if (thiSinh == null)
+            {
+                Console.WriteLine("Không có thông tin thí sinh để thêm.");
+                return;
+            }
+
+            string khoi = thiSinh switch
+            {
+                ThiSinhKhoiA _ => "A",
+                ThiSinhKhoiB _ => "B",
+                ThiSinhKhoiC _ => "C",
+                _ => string.Empty
+            };
+
+            if (!ql.ThemThiSinh(thiSinh))
+            {
+                Console.WriteLine($"Số báo danh đã tồn tại, không thể thêm thí sinh khối {khoi}.");
+                return;
+            }
+
+            Console.WriteLine($"Đã thêm thí sinh khối {khoi} thành công.");
+            ql.LuuVaoTxt(filePath);
+            Console.WriteLine("Dữ liệu đã được lưu vào tệp.");
+        }
+
+        private static void TimKiemTheoHoTen(QuanLyThiSinh ql)
+        {
             Console.Write("Nhập tên cần tìm kiếm: ");
             string tuKhoa = Console.ReadLine();
-            var ketQua = ql.TimTheoHoTen(tuKhoa);
+            var ketQua = ql.TimTheoHoTen(tuKhoa).ToList();
+
+            if (ketQua.Count == 0)
+            {
+                Console.WriteLine("Không tìm thấy thí sinh phù hợp.");
+                return;
+            }
+
             Console.WriteLine("===== KẾT QUẢ TÌM KIẾM =====");
             foreach (var ts in ketQua)
             {
                 ts.InThongTin();
                 Console.WriteLine();
             }
-
-            ql.LuuVaoTxt(filePath);
-
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the fixed input flow with a menu-driven loop covering adding candidates, listing, statistics, search, loading and saving
- extract repeated input code into dedicated helper methods for each exam block and reuse them within the menu actions
- ensure data is persisted whenever candidates are added and provide explicit load/save options for the user

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fa85c1848322b4053dc271b2e91a