### PR TITLE
Thêm chức năng cập nhật và xóa thí sinh

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -48,6 +48,61 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         {
             return danhSachThiSinh.FirstOrDefault(ts => ts.SoBD == soBD);
         }
+
+        public bool CapNhatThiSinh(string soBD, ThongTinThiSinh thongTinCapNhat)
+        {
+            if (string.IsNullOrWhiteSpace(soBD) || thongTinCapNhat == null)
+            {
+                return false;
+            }
+
+            var thiSinhHienTai = TimTheoSoBD(soBD);
+            if (thiSinhHienTai == null)
+            {
+                return false;
+            }
+
+            if (!string.Equals(thiSinhHienTai.SoBD, thongTinCapNhat.SoBD, StringComparison.Ordinal))
+            {
+                var thiSinhTrung = TimTheoSoBD(thongTinCapNhat.SoBD);
+                if (thiSinhTrung != null && !ReferenceEquals(thiSinhTrung, thiSinhHienTai))
+                {
+                    return false;
+                }
+            }
+
+            CapNhatThongTinCoBan(thiSinhHienTai, thongTinCapNhat);
+
+            if (thiSinhHienTai is ThiSinhKhoiA thiSinhKhoiA && thongTinCapNhat is ThiSinhKhoiA capNhatKhoiA)
+            {
+                CapNhatDiemKhoiA(thiSinhKhoiA, capNhatKhoiA);
+                return true;
+            }
+
+            if (thiSinhHienTai is ThiSinhKhoiB thiSinhKhoiB && thongTinCapNhat is ThiSinhKhoiB capNhatKhoiB)
+            {
+                CapNhatDiemKhoiB(thiSinhKhoiB, capNhatKhoiB);
+                return true;
+            }
+
+            if (thiSinhHienTai is ThiSinhKhoiC thiSinhKhoiC && thongTinCapNhat is ThiSinhKhoiC capNhatKhoiC)
+            {
+                CapNhatDiemKhoiC(thiSinhKhoiC, capNhatKhoiC);
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool XoaThiSinh(string soBD)
+        {
+            if (string.IsNullOrWhiteSpace(soBD))
+            {
+                return false;
+            }
+
+            return danhSachThiSinh.RemoveAll(ts => ts.SoBD == soBD) > 0;
+        }
         public void TimThuKhoa()
         {
             ThiSinhKhoiA thuKhoaA = null;
@@ -402,6 +457,52 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         private static string NormalizeText(string value)
         {
             return string.IsNullOrEmpty(value) ? string.Empty : value.Replace("|", "/");
+        }
+
+        private static void CapNhatThongTinCoBan(ThongTinThiSinh dich, ThongTinThiSinh nguon)
+        {
+            dich.SoBD = nguon.SoBD;
+            dich.HoTen = nguon.HoTen;
+            dich.NgaySinh = nguon.NgaySinh;
+            dich.DanToc = nguon.DanToc;
+            dich.GioiTinh = nguon.GioiTinh;
+            dich.NoiSinh = nguon.NoiSinh;
+            dich.DiaChi = nguon.DiaChi;
+            dich.SoCanCuoc = nguon.SoCanCuoc;
+            dich.SoDienThoai = nguon.SoDienThoai;
+            dich.Email = nguon.Email;
+            dich.KhuVuc = nguon.KhuVuc;
+            dich.DoiTuongUuTien = nguon.DoiTuongUuTien;
+            dich.HoiDongThi = nguon.HoiDongThi;
+        }
+
+        private static void CapNhatDiemKhoiA(ThiSinhKhoiA dich, ThiSinhKhoiA nguon)
+        {
+            dich.Diem.Toan = nguon.Diem.Toan;
+            dich.Diem.Van = nguon.Diem.Van;
+            dich.Diem.Anh = nguon.Diem.Anh;
+            dich.Diem.Ly = nguon.Diem.Ly;
+            dich.Diem.Hoa = nguon.Diem.Hoa;
+            dich.Diem.Sinh = nguon.Diem.Sinh;
+        }
+
+        private static void CapNhatDiemKhoiB(ThiSinhKhoiB dich, ThiSinhKhoiB nguon)
+        {
+            dich.Diem.Toan = nguon.Diem.Toan;
+            dich.Diem.Van = nguon.Diem.Van;
+            dich.Diem.Anh = nguon.Diem.Anh;
+            dich.Diem.Hoa = nguon.Diem.Hoa;
+            dich.Diem.Sinh = nguon.Diem.Sinh;
+        }
+
+        private static void CapNhatDiemKhoiC(ThiSinhKhoiC dich, ThiSinhKhoiC nguon)
+        {
+            dich.Diem.Toan = nguon.Diem.Toan;
+            dich.Diem.Van = nguon.Diem.Van;
+            dich.Diem.Anh = nguon.Diem.Anh;
+            dich.Diem.Su = nguon.Diem.Su;
+            dich.Diem.Dia = nguon.Diem.Dia;
+            dich.Diem.GDCD = nguon.Diem.GDCD;
         }
 
         private static double ParseDiem(string giaTri, string tenMon)

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
@@ -56,6 +56,12 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                     case "9":
                         ql.LuuVaoTxt(filePath);
                         break;
+                    case "10":
+                        CapNhatThongTinThiSinh(ql, filePath);
+                        break;
+                    case "11":
+                        XoaThiSinh(ql, filePath);
+                        break;
                     case "0":
                         thoat = true;
                         break;
@@ -80,6 +86,8 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             Console.WriteLine("7. Tìm kiếm thí sinh theo họ tên");
             Console.WriteLine("8. Tải dữ liệu từ tệp");
             Console.WriteLine("9. Lưu dữ liệu ra tệp");
+            Console.WriteLine("10. Cập nhật thông tin thí sinh");
+            Console.WriteLine("11. Xóa thí sinh");
             Console.WriteLine("0. Thoát");
         }
 
@@ -167,6 +175,78 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                 ts.InThongTin();
                 Console.WriteLine();
             }
+        }
+
+        private static void CapNhatThongTinThiSinh(QuanLyThiSinh ql, string filePath)
+        {
+            Console.Write("Nhập số báo danh cần cập nhật: ");
+            string soBD = Console.ReadLine();
+
+            if (string.IsNullOrWhiteSpace(soBD))
+            {
+                Console.WriteLine("Số báo danh không hợp lệ.");
+                return;
+            }
+
+            var thiSinhHienTai = ql.TimTheoSoBD(soBD);
+            if (thiSinhHienTai == null)
+            {
+                Console.WriteLine("Không tìm thấy thí sinh với số báo danh đã nhập.");
+                return;
+            }
+
+            Console.WriteLine("Nhập thông tin mới cho thí sinh (các thông tin cũ sẽ được thay thế).");
+
+            ThongTinThiSinh thongTinCapNhat;
+            if (thiSinhHienTai is ThiSinhKhoiA)
+            {
+                thongTinCapNhat = NhapThiSinhKhoiA();
+            }
+            else if (thiSinhHienTai is ThiSinhKhoiB)
+            {
+                thongTinCapNhat = NhapThiSinhKhoiB();
+            }
+            else if (thiSinhHienTai is ThiSinhKhoiC)
+            {
+                thongTinCapNhat = NhapThiSinhKhoiC();
+            }
+            else
+            {
+                Console.WriteLine("Loại thí sinh không xác định, không thể cập nhật.");
+                return;
+            }
+
+            if (!ql.CapNhatThiSinh(soBD, thongTinCapNhat))
+            {
+                Console.WriteLine("Cập nhật thất bại. Có thể số báo danh mới đã tồn tại hoặc loại khối không khớp.");
+                return;
+            }
+
+            Console.WriteLine("Cập nhật thí sinh thành công.");
+            ql.LuuVaoTxt(filePath);
+            Console.WriteLine("Dữ liệu đã được lưu vào tệp.");
+        }
+
+        private static void XoaThiSinh(QuanLyThiSinh ql, string filePath)
+        {
+            Console.Write("Nhập số báo danh cần xóa: ");
+            string soBD = Console.ReadLine();
+
+            if (string.IsNullOrWhiteSpace(soBD))
+            {
+                Console.WriteLine("Số báo danh không hợp lệ.");
+                return;
+            }
+
+            if (!ql.XoaThiSinh(soBD))
+            {
+                Console.WriteLine("Không tìm thấy thí sinh với số báo danh đã nhập.");
+                return;
+            }
+
+            Console.WriteLine($"Đã xóa thí sinh có số báo danh {soBD}.");
+            ql.LuuVaoTxt(filePath);
+            Console.WriteLine("Dữ liệu đã được lưu vào tệp.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- thêm API cập nhật và xóa thí sinh trong bộ quản lý dựa trên số báo danh
- bổ sung menu tương tác để người dùng cập nhật hoặc xóa thí sinh và lưu lại dữ liệu

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fe5a08148322ac175bf1c176a2de