### PR TITLE
Điều chỉnh công thức tính điểm ưu tiên

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiA.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiA.cs
@@ -19,17 +19,24 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             return Diem.Toan + Diem.Ly + Diem.Hoa;
         }
         public double TinhDiemVung() => TinhDiemCongKhuVuc();
-        public double TinhDiemUuTien() => TinhDiemCongUuTien();
+        public double TinhDiemUuTien() => TinhTongDiemUuTien(TinhDiem());
         public double TongDiem()
         {
-            return TinhDiem() + TinhDiemVung() + TinhDiemUuTien();
+            var tongDiemBaMon = TinhDiem();
+            return tongDiemBaMon + TinhTongDiemUuTien(tongDiemBaMon);
         }
         public void In()
         {
             Console.WriteLine("=== Thí sinh khối A ===");
             base.InThongTin();
             Diem.InDiem();
-            Console.WriteLine($"Tổng điểm khối A:{TongDiem()}");
+            var tongDiemBaMon = TinhDiem();
+            var diemUuTienCoBan = Math.Round(TinhDiemCongKhuVuc() + TinhDiemCongUuTien(), 2, MidpointRounding.AwayFromZero);
+            var diemUuTienApDung = TinhTongDiemUuTien(tongDiemBaMon);
+            Console.WriteLine($"Tổng điểm 3 môn: {tongDiemBaMon}");
+            Console.WriteLine($"Điểm ưu tiên cơ bản (KV + UT): {diemUuTienCoBan}");
+            Console.WriteLine($"Điểm ưu tiên áp dụng: {diemUuTienApDung}");
+            Console.WriteLine($"Tổng điểm khối A: {tongDiemBaMon + diemUuTienApDung}");
         }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiB.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiB.cs
@@ -19,17 +19,24 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             return Diem.Toan + Diem.Hoa + Diem.Sinh;
         }
         public double TinhDiemVung() => TinhDiemCongKhuVuc();
-        public double TinhDiemUuTien() => TinhDiemCongUuTien();
+        public double TinhDiemUuTien() => TinhTongDiemUuTien(TinhDiem());
         public double TongDiem()
         {
-            return TinhDiem() + TinhDiemVung() + TinhDiemUuTien();
+            var tongDiemBaMon = TinhDiem();
+            return tongDiemBaMon + TinhTongDiemUuTien(tongDiemBaMon);
         }
         public void In()
         {
             Console.WriteLine("=== Thí sinh khối B ===");
             base.InThongTin();
             Diem.InDiem();
-            Console.WriteLine($"Tổng điểm khối B: {TongDiem()}");
+            var tongDiemBaMon = TinhDiem();
+            var diemUuTienCoBan = Math.Round(TinhDiemCongKhuVuc() + TinhDiemCongUuTien(), 2, MidpointRounding.AwayFromZero);
+            var diemUuTienApDung = TinhTongDiemUuTien(tongDiemBaMon);
+            Console.WriteLine($"Tổng điểm 3 môn: {tongDiemBaMon}");
+            Console.WriteLine($"Điểm ưu tiên cơ bản (KV + UT): {diemUuTienCoBan}");
+            Console.WriteLine($"Điểm ưu tiên áp dụng: {diemUuTienApDung}");
+            Console.WriteLine($"Tổng điểm khối B: {tongDiemBaMon + diemUuTienApDung}");
         }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiC.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiC.cs
@@ -19,17 +19,24 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             return Diem.Van + Diem.Su + Diem.Dia;
         }
         public double TinhDiemVung() => TinhDiemCongKhuVuc();
-        public double TinhDiemUuTien() => TinhDiemCongUuTien();
+        public double TinhDiemUuTien() => TinhTongDiemUuTien(TinhDiem());
         public double TongDiem()
         {
-            return TinhDiem() + TinhDiemVung() + TinhDiemUuTien();
+            var tongDiemBaMon = TinhDiem();
+            return tongDiemBaMon + TinhTongDiemUuTien(tongDiemBaMon);
         }
         public void In()
         {
             Console.WriteLine("=== Thí sinh khối C ===");
             base.InThongTin();
             Diem.InDiem();
-            Console.WriteLine($"Tổng điểm khối C: {TongDiem()}");
+            var tongDiemBaMon = TinhDiem();
+            var diemUuTienCoBan = Math.Round(TinhDiemCongKhuVuc() + TinhDiemCongUuTien(), 2, MidpointRounding.AwayFromZero);
+            var diemUuTienApDung = TinhTongDiemUuTien(tongDiemBaMon);
+            Console.WriteLine($"Tổng điểm 3 môn: {tongDiemBaMon}");
+            Console.WriteLine($"Điểm ưu tiên cơ bản (KV + UT): {diemUuTienCoBan}");
+            Console.WriteLine($"Điểm ưu tiên áp dụng: {diemUuTienApDung}");
+            Console.WriteLine($"Tổng điểm khối C: {tongDiemBaMon + diemUuTienApDung}");
         }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
@@ -122,6 +122,34 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             }
         }
 
+        protected double TinhTongDiemUuTien(double tongDiemBaMon)
+        {
+            var diemUuTienCoBan = TinhDiemCongKhuVuc() + TinhDiemCongUuTien();
+            if (diemUuTienCoBan <= 0)
+            {
+                return 0;
+            }
+
+            if (tongDiemBaMon < 22.5)
+            {
+                return Math.Round(diemUuTienCoBan, 2, MidpointRounding.AwayFromZero);
+            }
+
+            var heSo = (30 - tongDiemBaMon) / 7.5;
+            if (heSo <= 0)
+            {
+                return 0;
+            }
+
+            if (heSo > 1)
+            {
+                heSo = 1;
+            }
+
+            var diemUuTien = diemUuTienCoBan * heSo;
+            return Math.Round(diemUuTien, 2, MidpointRounding.AwayFromZero);
+        }
+
         private static string NhapChuoiKhongRong(string thongDiep)
         {
             string ketQua;


### PR DESCRIPTION
## Summary
- cập nhật công thức tính tổng điểm ưu tiên theo ngưỡng 22.5 và hệ số giảm dần
- hiển thị rõ tổng điểm 3 môn, điểm ưu tiên cơ bản và điểm ưu tiên sau điều chỉnh khi in thông tin thí sinh

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d808f82f088322bb81f9e265d3bada