### PR TITLE
Fix physics score update for block B candidates

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -493,6 +493,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             dich.Diem.Toan = nguon.Diem.Toan;
             dich.Diem.Van = nguon.Diem.Van;
             dich.Diem.Anh = nguon.Diem.Anh;
+            dich.Diem.Ly = nguon.Diem.Ly;
             dich.Diem.Hoa = nguon.Diem.Hoa;
             dich.Diem.Sinh = nguon.Diem.Sinh;
         }


### PR DESCRIPTION
## Summary
- ensure physics (Lý) score is copied when updating block B candidates

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d80c27d0fc832296d40bd7ad359372