### PR TITLE
Add religion field to candidates and clarify file format guidance

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -9,7 +9,11 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
     public class QuanLyThiSinh
     {
         private List<ThongTinThiSinh> danhSachThiSinh;
-        private const string FileStructureGuidance = "Định dạng tệp: Khoi|SoBD|HoTen|NgaySinh|DanToc|GioiTinh|NoiSinh|DiaChi|SoCanCuoc|SoDienThoai|Email|KhuVuc|DoiTuongUuTien|HoiDongThi|Mon1|Mon2|Mon3. Khối A: Mon1=Toán, Mon2=Lý, Mon3=Hóa; Khối B: Mon1=Toán, Mon2=Hóa, Mon3=Sinh; Khối C: Mon1=Văn, Mon2=Sử, Mon3=Địa.";
+        private const string FileStructureGuidance = "Định dạng tệp:\n" +
+            "Khoi|SoBD|HoTen|NgaySinh|DanToc|TonGiao|GioiTinh|NoiSinh|DiaChi|SoCanCuoc|SoDienThoai|Email|KhuVuc|DoiTuongUuTien|HoiDongThi|Mon1|Mon2|Mon3\n" +
+            "Khối A: Mon1=Toán, Mon2=Lý, Mon3=Hóa\n" +
+            "Khối B: Mon1=Toán, Mon2=Hóa, Mon3=Sinh\n" +
+            "Khối C: Mon1=Văn, Mon2=Sử, Mon3=Địa";
         public QuanLyThiSinh()
         {
             danhSachThiSinh = new List<ThongTinThiSinh>();
@@ -200,7 +204,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
                 var headers = new[]
                 {
-                    "Khoi", "SoBD", "HoTen", "NgaySinh", "DanToc", "GioiTinh", "NoiSinh", "DiaChi",
+                    "Khoi", "SoBD", "HoTen", "NgaySinh", "DanToc", "TonGiao", "GioiTinh", "NoiSinh", "DiaChi",
                     "SoCanCuoc", "SoDienThoai", "Email", "KhuVuc", "DoiTuongUuTien", "HoiDongThi",
                     "Mon1", "Mon2", "Mon3"
                 };
@@ -225,15 +229,16 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                         fields[2] = NormalizeText(ts.HoTen);
                         fields[3] = ts.NgaySinh.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture);
                         fields[4] = NormalizeText(ts.DanToc);
-                        fields[5] = NormalizeText(ts.GioiTinh);
-                        fields[6] = NormalizeText(ts.NoiSinh);
-                        fields[7] = NormalizeText(ts.DiaChi);
-                        fields[8] = NormalizeText(ts.SoCanCuoc);
-                        fields[9] = NormalizeText(ts.SoDienThoai);
-                        fields[10] = NormalizeText(ts.Email);
-                        fields[11] = NormalizeText(ts.KhuVuc);
-                        fields[12] = ts.DoiTuongUuTien.ToString(CultureInfo.InvariantCulture);
-                        fields[13] = NormalizeText(ts.HoiDongThi);
+                        fields[5] = NormalizeText(ts.TonGiao);
+                        fields[6] = NormalizeText(ts.GioiTinh);
+                        fields[7] = NormalizeText(ts.NoiSinh);
+                        fields[8] = NormalizeText(ts.DiaChi);
+                        fields[9] = NormalizeText(ts.SoCanCuoc);
+                        fields[10] = NormalizeText(ts.SoDienThoai);
+                        fields[11] = NormalizeText(ts.Email);
+                        fields[12] = NormalizeText(ts.KhuVuc);
+                        fields[13] = ts.DoiTuongUuTien.ToString(CultureInfo.InvariantCulture);
+                        fields[14] = NormalizeText(ts.HoiDongThi);
 
                         double? mon1 = null;
                         double? mon2 = null;
@@ -258,9 +263,9 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                                 break;
                         }
 
-                        fields[14] = FormatScore(mon1);
-                        fields[15] = FormatScore(mon2);
-                        fields[16] = FormatScore(mon3);
+                        fields[15] = FormatScore(mon1);
+                        fields[16] = FormatScore(mon2);
+                        fields[17] = FormatScore(mon3);
 
                         writer.WriteLine(string.Join("|", fields));
                     }
@@ -318,7 +323,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                         try
                         {
                             var parts = line.Split('|');
-                            if (parts.Length < 17)
+                            if (parts.Length < 18)
                             {
                                 throw new FormatException("Không đủ cột dữ liệu");
                             }
@@ -338,15 +343,16 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                             var hoTen = parts[2];
                             var ngaySinhStr = parts[3];
                             var danToc = parts[4];
-                            var gioiTinh = parts[5];
-                            var noiSinh = parts[6];
-                            var diaChi = parts[7];
-                            var soCanCuoc = parts[8];
-                            var soDienThoai = parts[9];
-                            var email = parts[10];
-                            var khuVuc = parts[11];
-                            var doiTuongStr = parts[12];
-                            var hoiDongThi = parts[13];
+                            var tonGiao = parts[5];
+                            var gioiTinh = parts[6];
+                            var noiSinh = parts[7];
+                            var diaChi = parts[8];
+                            var soCanCuoc = parts[9];
+                            var soDienThoai = parts[10];
+                            var email = parts[11];
+                            var khuVuc = parts[12];
+                            var doiTuongStr = parts[13];
+                            var hoiDongThi = parts[14];
 
                             if (string.IsNullOrEmpty(ngaySinhStr))
                             {
@@ -368,23 +374,23 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                             {
                                 case "A":
                                     var thiSinhA = new ThiSinhKhoiA();
-                                    thiSinhA.Diem.Toan = ParseDiem(parts[14], "điểm Toán", khoiTrim);
-                                    thiSinhA.Diem.Ly = ParseDiem(parts[15], "điểm Lý", khoiTrim);
-                                    thiSinhA.Diem.Hoa = ParseDiem(parts[16], "điểm Hóa", khoiTrim);
+                                    thiSinhA.Diem.Toan = ParseDiem(parts[15], "điểm Toán", khoiTrim);
+                                    thiSinhA.Diem.Ly = ParseDiem(parts[16], "điểm Lý", khoiTrim);
+                                    thiSinhA.Diem.Hoa = ParseDiem(parts[17], "điểm Hóa", khoiTrim);
                                     thiSinh = thiSinhA;
                                     break;
                                 case "B":
                                     var thiSinhB = new ThiSinhKhoiB();
-                                    thiSinhB.Diem.Toan = ParseDiem(parts[14], "điểm Toán", khoiTrim);
-                                    thiSinhB.Diem.Hoa = ParseDiem(parts[15], "điểm Hóa", khoiTrim);
-                                    thiSinhB.Diem.Sinh = ParseDiem(parts[16], "điểm Sinh", khoiTrim);
+                                    thiSinhB.Diem.Toan = ParseDiem(parts[15], "điểm Toán", khoiTrim);
+                                    thiSinhB.Diem.Hoa = ParseDiem(parts[16], "điểm Hóa", khoiTrim);
+                                    thiSinhB.Diem.Sinh = ParseDiem(parts[17], "điểm Sinh", khoiTrim);
                                     thiSinh = thiSinhB;
                                     break;
                                 case "C":
                                     var thiSinhC = new ThiSinhKhoiC();
-                                    thiSinhC.Diem.Van = ParseDiem(parts[14], "điểm Văn", khoiTrim);
-                                    thiSinhC.Diem.Su = ParseDiem(parts[15], "điểm Sử", khoiTrim);
-                                    thiSinhC.Diem.Dia = ParseDiem(parts[16], "điểm Địa", khoiTrim);
+                                    thiSinhC.Diem.Van = ParseDiem(parts[15], "điểm Văn", khoiTrim);
+                                    thiSinhC.Diem.Su = ParseDiem(parts[16], "điểm Sử", khoiTrim);
+                                    thiSinhC.Diem.Dia = ParseDiem(parts[17], "điểm Địa", khoiTrim);
                                     thiSinh = thiSinhC;
                                     break;
                                 default:
@@ -395,6 +401,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                             thiSinh.HoTen = hoTen;
                             thiSinh.NgaySinh = ngaySinh;
                             thiSinh.DanToc = danToc;
+                            thiSinh.TonGiao = tonGiao;
                             thiSinh.GioiTinh = gioiTinh;
                             thiSinh.NoiSinh = noiSinh;
                             thiSinh.DiaChi = diaChi;
@@ -438,6 +445,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             dich.HoTen = nguon.HoTen;
             dich.NgaySinh = nguon.NgaySinh;
             dich.DanToc = nguon.DanToc;
+            dich.TonGiao = nguon.TonGiao;
             dich.GioiTinh = nguon.GioiTinh;
             dich.NoiSinh = nguon.NoiSinh;
             dich.DiaChi = nguon.DiaChi;

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
@@ -10,6 +10,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public string HoTen { get; set; }
         public DateTime NgaySinh { get; set; }
         public string DanToc { get; set; }
+        public string TonGiao { get; set; }
         public string GioiTinh { get; set; }
         public string NoiSinh { get; set; }
         public string DiaChi { get; set; }
@@ -29,6 +30,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             string hoTen,
             DateTime ngaySinh,
             string danToc,
+            string tonGiao,
             string gioiTinh,
             string noiSinh,
             string diaChi,
@@ -43,6 +45,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             HoTen = hoTen;
             NgaySinh = ngaySinh;
             DanToc = danToc;
+            TonGiao = tonGiao;
             GioiTinh = gioiTinh;
             NoiSinh = noiSinh;
             DiaChi = diaChi;
@@ -62,6 +65,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             NgaySinh = NhapNgaySinh();
 
             DanToc = NhapChuoiKhongRong("Nhập dân tộc: ");
+            TonGiao = NhapChuoiKhongRong("Nhập tôn giáo: ");
             GioiTinh = NhapGioiTinh();
             NoiSinh = NhapChuoiKhongRong("Nhập nơi sinh: ");
             DiaChi = NhapChuoiKhongRong("Nhập địa chỉ: ");
@@ -83,6 +87,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             Console.WriteLine("Ngày sinh       : {0:dd/MM/yyyy}", NgaySinh);
             Console.WriteLine("Giới tính       : {0}", GioiTinh);
             Console.WriteLine("Dân tộc         : {0}", DanToc);
+            Console.WriteLine("Tôn giáo        : {0}", TonGiao);
             Console.WriteLine("Nơi sinh        : {0}", NoiSinh);
             Console.WriteLine("Địa chỉ         : {0}", DiaChi);
             Console.WriteLine("Số căn cước     : {0}", SoCanCuoc);


### PR DESCRIPTION
## Summary
- add the TonGiao (religion) field to candidate input, display, persistence, and updates
- refresh the TXT import/export headers to include the new field and align score columns
- reformat the file structure guidance into a multi-line description for clearer console output

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ef9f6fbc83229be6d03a1eba23d2