### PR TITLE
Validate score ranges during import

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -13,7 +13,8 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             "Khoi|SoBD|HoTen|NgaySinh|DanToc|TonGiao|GioiTinh|NoiSinh|DiaChi|SoCanCuoc|SoDienThoai|Email|KhuVuc|DoiTuongUuTien|HoiDongThi|Mon1|Mon2|Mon3\n" +
             "Khối A: Mon1=Toán, Mon2=Lý, Mon3=Hóa\n" +
             "Khối B: Mon1=Toán, Mon2=Hóa, Mon3=Sinh\n" +
-            "Khối C: Mon1=Văn, Mon2=Sử, Mon3=Địa";
+            "Khối C: Mon1=Văn, Mon2=Sử, Mon3=Địa\n" +
+            "Điểm mỗi môn: giá trị từ 0 đến 10, dùng dấu chấm hoặc dấu phẩy cho phần thập phân (ví dụ: 8.5 hoặc 8,5).";
         public QuanLyThiSinh()
         {
             danhSachThiSinh = new List<ThongTinThiSinh>();
@@ -483,13 +484,14 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                 throw new FormatException($"Thiếu {tenMon}. {FileStructureGuidance}");
             }
 
-            if (double.TryParse(giaTri, NumberStyles.Float, CultureInfo.InvariantCulture, out var diem))
+            if (double.TryParse(giaTri, NumberStyles.Float, CultureInfo.InvariantCulture, out var diem) ||
+                double.TryParse(giaTri, NumberStyles.Float, CultureInfo.GetCultureInfo("vi-VN"), out diem))
             {
-                return diem;
-            }
+                if (diem < 0 || diem > 10)
+                {
+                    throw new FormatException($"{tenMon} cho khối {khoi} phải nằm trong khoảng 0 đến 10. {FileStructureGuidance}");
+                }
 
-            if (double.TryParse(giaTri, NumberStyles.Float, CultureInfo.GetCultureInfo("vi-VN"), out diem))
-            {
                 return diem;
             }
 


### PR DESCRIPTION
## Summary
- add validation to ensure imported subject scores stay within the 0–10 range
- expand the import file guidance to describe the expected score range and decimal separators

## Testing
- `dotnet build "Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.sln"` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d95a7a5ad48322a3c44e7f800d563b