### PR TITLE
Ensure candidate updates respect block types

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -77,27 +77,49 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                 }
             }
 
-            CapNhatThongTinCoBan(thiSinhHienTai, thongTinCapNhat);
-
-            if (thiSinhHienTai is ThiSinhKhoiA thiSinhKhoiA && thongTinCapNhat is ThiSinhKhoiA capNhatKhoiA)
+            if (thiSinhHienTai is ThiSinhKhoiA thiSinhKhoiA)
             {
+                if (!(thongTinCapNhat is ThiSinhKhoiA capNhatKhoiA))
+                {
+                    return false;
+                }
+
+                CapNhatThongTinCoBan(thiSinhKhoiA, capNhatKhoiA);
                 CapNhatDiemKhoiA(thiSinhKhoiA, capNhatKhoiA);
                 return true;
             }
 
-            if (thiSinhHienTai is ThiSinhKhoiB thiSinhKhoiB && thongTinCapNhat is ThiSinhKhoiB capNhatKhoiB)
+            if (thiSinhHienTai is ThiSinhKhoiB thiSinhKhoiB)
             {
+                if (!(thongTinCapNhat is ThiSinhKhoiB capNhatKhoiB))
+                {
+                    return false;
+                }
+
+                CapNhatThongTinCoBan(thiSinhKhoiB, capNhatKhoiB);
                 CapNhatDiemKhoiB(thiSinhKhoiB, capNhatKhoiB);
                 return true;
             }
 
-            if (thiSinhHienTai is ThiSinhKhoiC thiSinhKhoiC && thongTinCapNhat is ThiSinhKhoiC capNhatKhoiC)
+            if (thiSinhHienTai is ThiSinhKhoiC thiSinhKhoiC)
             {
+                if (!(thongTinCapNhat is ThiSinhKhoiC capNhatKhoiC))
+                {
+                    return false;
+                }
+
+                CapNhatThongTinCoBan(thiSinhKhoiC, capNhatKhoiC);
                 CapNhatDiemKhoiC(thiSinhKhoiC, capNhatKhoiC);
                 return true;
             }
 
-            return false;
+            if (thongTinCapNhat.GetType() != thiSinhHienTai.GetType())
+            {
+                return false;
+            }
+
+            CapNhatThongTinCoBan(thiSinhHienTai, thongTinCapNhat);
+            return true;
         }
 
         public bool XoaThiSinh(string soBD)


### PR DESCRIPTION
## Summary
- guard CapNhatThiSinh so that basic info is only updated after confirming the block-specific type matches
- return false immediately for mismatched block types and fall back to base updates when both objects share the same non-block type

## Testing
- dotnet run (manual check that updating a block A candidate with block B data returns false and leaves the original data intact)


------
https://chatgpt.com/codex/tasks/task_e_68d960299f6083229856b3d9eabcfdfe