### PR TITLE
Improve NgayThangNam parsing and validation

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
@@ -174,18 +174,18 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             while (true)
             {
                 giaTri = Console.ReadLine();
-                try
+                if (NgayThangNam.TryParse(giaTri, out var ngayThangNam))
                 {
-                    return NgayThangNam.Parse(giaTri);
+                    return ngayThangNam;
                 }
-                catch (FormatException)
+
+                if (string.IsNullOrWhiteSpace(giaTri))
                 {
-                    Console.Write("Sai định dạng! Nhập lại (dd/MM/yyyy): ");
+                    Console.Write("Ngày sinh không được để trống! Nhập lại (dd/MM/yyyy): ");
+                    continue;
                 }
-                catch (ArgumentOutOfRangeException)
-                {
-                    Console.Write("Giá trị ngày sinh không hợp lệ! Nhập lại (dd/MM/yyyy): ");
-                }
+
+                Console.Write("Sai định dạng hoặc ngày không hợp lệ! Nhập lại (dd/MM/yyyy): ");
 
             }
         }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/NgayThangNam.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/NgayThangNam.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
     public sealed class NgayThangNam : IEquatable<NgayThangNam>
     {
+        private static readonly string[] SupportedFormats = { "dd/MM/yyyy", "d/M/yyyy" };
+        private static readonly CultureInfo[] SupportedCultures = CreateSupportedCultures();
+
         public int Ngay { get; }
         public int Thang { get; }
         public int Nam { get; }
@@ -33,12 +37,50 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                 throw new FormatException("Ngày sinh không được để trống.");
             }
 
-            if (!DateTime.TryParseExact(value.Trim(), "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+            if (TryParse(value, out var ketQua))
             {
-                throw new FormatException("Ngày sinh phải theo định dạng dd/MM/yyyy.");
+                return ketQua;
             }
 
-            return FromDateTime(date);
+            throw new FormatException("Ngày sinh phải theo định dạng dd/MM/yyyy và là một ngày hợp lệ.");
+        }
+
+        public static bool TryParse(string value, out NgayThangNam result)
+        {
+            result = null;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var trimmed = value.Trim();
+            foreach (var culture in SupportedCultures)
+            {
+                if (DateTime.TryParseExact(trimmed, SupportedFormats, culture, DateTimeStyles.None, out var date))
+                {
+                    result = FromDateTime(date);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static CultureInfo[] CreateSupportedCultures()
+        {
+            var cultures = new List<CultureInfo> { CultureInfo.InvariantCulture };
+
+            try
+            {
+                cultures.Add(CultureInfo.GetCultureInfo("vi-VN"));
+            }
+            catch (CultureNotFoundException)
+            {
+                // Bỏ qua nếu môi trường không hỗ trợ mã văn hóa vi-VN.
+            }
+
+            return cultures.ToArray();
         }
 
         public DateTime ToDateTime()
@@ -49,6 +91,21 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public override string ToString()
         {
             return $"{Ngay:D2}/{Thang:D2}/{Nam:D4}";
+        }
+
+        public static implicit operator DateTime(NgayThangNam value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return value.ToDateTime();
+        }
+
+        public static implicit operator NgayThangNam(DateTime value)
+        {
+            return FromDateTime(value);
         }
 
         public bool Equals(NgayThangNam other)
@@ -73,7 +130,14 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Ngay, Thang, Nam);
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 23) + Ngay;
+                hash = (hash * 23) + Thang;
+                hash = (hash * 23) + Nam;
+                return hash;
+            }
         }
 
         private static bool IsValid(int ngay, int thang, int nam)


### PR DESCRIPTION
## Summary
- extend the NgayThangNam value object with TryParse support, culture fallbacks, and implicit conversions for DateTime interoperability
- update candidate input flow to reuse the new TryParse logic and provide clearer retry prompts

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d95a7a5ad48322a3c44e7f800d563b