### PR TITLE
Improve score input parsing for locale-specific decimals

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
@@ -22,14 +22,8 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
         private static double NhapDiemMon(string tenMon)
         {
-            double diem;
             Console.Write($"Nhập điểm {tenMon}: ");
-            while (!double.TryParse(Console.ReadLine(), out diem) || diem < 0 || diem > 10)
-            {
-                Console.Write($"Điểm không hợp lệ! Nhập lại điểm {tenMon} (0-10): ");
-            }
-
-            return Math.Round(diem, 2);
+            return DiemThiInputHelper.ReadScoreFromConsole(tenMon);
         }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
@@ -22,14 +22,8 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
         private static double NhapDiemMon(string tenMon)
         {
-            double diem;
             Console.Write($"Nhập điểm {tenMon}: ");
-            while (!double.TryParse(Console.ReadLine(), out diem) || diem < 0 || diem > 10)
-            {
-                Console.Write($"Điểm không hợp lệ! Nhập lại điểm {tenMon} (0-10): ");
-            }
-
-            return Math.Round(diem, 2);
+            return DiemThiInputHelper.ReadScoreFromConsole(tenMon);
         }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
@@ -22,14 +22,8 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
         private static double NhapDiemMon(string tenMon)
         {
-            double diem;
             Console.Write($"Nhập điểm {tenMon}: ");
-            while (!double.TryParse(Console.ReadLine(), out diem) || diem < 0 || diem > 10)
-            {
-                Console.Write($"Điểm không hợp lệ! Nhập lại điểm {tenMon} (0-10): ");
-            }
-
-            return Math.Round(diem, 2);
+            return DiemThiInputHelper.ReadScoreFromConsole(tenMon);
         }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.csproj
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.csproj
@@ -47,6 +47,7 @@
     <Compile Include="%28Diem%29DiemKhoiA.cs" />
     <Compile Include="%28Diem%29DiemKhoiB.cs" />
     <Compile Include="%28Diem%29DiemKhoiC.cs" />
+    <Compile Include="DiemThiInputHelper.cs" />
     <Compile Include="%28TS%29IThiKhoi.cs" />
     <Compile Include="%28Diem%29IDiemThi.cs" />
     <Compile Include="Program.cs" />

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/DiemThiInputHelper.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/DiemThiInputHelper.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Globalization;
+
+namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
+{
+    internal static class DiemThiInputHelper
+    {
+        private static readonly CultureInfo[] SupportedCultures =
+        {
+            CultureInfo.InvariantCulture,
+            CultureInfo.GetCultureInfo("vi-VN")
+        };
+
+        public static double ReadScoreFromConsole(string subjectName)
+        {
+            while (true)
+            {
+                var input = Console.ReadLine();
+                if (TryParseScore(input, out var score) && score >= 0 && score <= 10)
+                {
+                    return Math.Round(score, 2, MidpointRounding.AwayFromZero);
+                }
+
+                Console.Write($"Điểm không hợp lệ! Nhập lại điểm {subjectName} (0-10): ");
+            }
+        }
+
+        private static bool TryParseScore(string value, out double score)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                value = value.Trim();
+                foreach (var culture in SupportedCultures)
+                {
+                    if (double.TryParse(value, NumberStyles.Float, culture, out score))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            score = default;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow entering exam scores with either dot or comma decimal separators by centralizing parsing logic
- reuse the new helper across all exam blocks and include it in the project build

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d970f2341483228d365cbafef1b92d