### PR TITLE
Streamline NgayThangNam handling without Parse helpers

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -385,7 +385,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                                 throw new FormatException("Thiếu đối tượng ưu tiên");
                             }
 
-                            var ngaySinh = NgayThangNam.Parse(ngaySinhStr);
+                            var ngaySinh = DocNgaySinhTuChuoi(ngaySinhStr);
                             var doiTuongUuTien = int.Parse(doiTuongStr, CultureInfo.InvariantCulture);
 
                             ThongTinThiSinh thiSinh = null;
@@ -497,6 +497,37 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             dich.Diem.Van = nguon.Diem.Van;
             dich.Diem.Su = nguon.Diem.Su;
             dich.Diem.Dia = nguon.Diem.Dia;
+        }
+
+        private static NgayThangNam DocNgaySinhTuChuoi(string giaTri)
+        {
+            if (string.IsNullOrWhiteSpace(giaTri))
+            {
+                throw new FormatException("Thiếu ngày sinh.");
+            }
+
+            var parts = giaTri
+                .Split(new[] { '/', '-', '.', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 3)
+            {
+                throw new FormatException("Ngày sinh phải gồm 3 phần: ngày/tháng/năm (ví dụ 01/02/2003).");
+            }
+
+            if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var ngay) ||
+                !int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var thang) ||
+                !int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var nam))
+            {
+                throw new FormatException("Ngày sinh chỉ được phép chứa chữ số.");
+            }
+
+            try
+            {
+                return new NgayThangNam(ngay, thang, nam);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                throw new FormatException("Giá trị ngày sinh không hợp lệ.");
+            }
         }
 
         private static double ParseDiem(string giaTri, string tenMon, string khoi)

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
@@ -169,24 +169,35 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
         private static NgayThangNam NhapNgaySinh()
         {
-            Console.Write("Nhập ngày sinh (dd/MM/yyyy): ");
-            string giaTri;
             while (true)
             {
-                giaTri = Console.ReadLine();
+                var ngay = NhapSoNguyen("Nhập ngày: ");
+                var thang = NhapSoNguyen("Nhập tháng: ");
+                var nam = NhapSoNguyen("Nhập năm: ");
+
                 try
                 {
-                    return NgayThangNam.Parse(giaTri);
-                }
-                catch (FormatException)
-                {
-                    Console.Write("Sai định dạng! Nhập lại (dd/MM/yyyy): ");
+                    return new NgayThangNam(ngay, thang, nam);
                 }
                 catch (ArgumentOutOfRangeException)
                 {
-                    Console.Write("Giá trị ngày sinh không hợp lệ! Nhập lại (dd/MM/yyyy): ");
+                    Console.WriteLine("Ngày sinh không hợp lệ, vui lòng nhập lại.");
+                }
+            }
+        }
+
+        private static int NhapSoNguyen(string thongDiep)
+        {
+            while (true)
+            {
+                Console.Write(thongDiep);
+                var duLieu = Console.ReadLine();
+                if (int.TryParse(duLieu, NumberStyles.Integer, CultureInfo.InvariantCulture, out var giaTri))
+                {
+                    return giaTri;
                 }
 
+                Console.WriteLine("Giá trị phải là số nguyên. Vui lòng nhập lại.");
             }
         }
 


### PR DESCRIPTION
## Summary
- remove the static parsing helpers from `NgayThangNam` to keep the value object minimal
- parse birthdates locally when loading data from text files and surface clearer validation errors
- adjust console input to collect day, month, and year separately before constructing `NgayThangNam`

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daaeb187808322bdb64f4cd4d5534a