### PR TITLE
Add interactive candidate update workflow

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -55,9 +55,9 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             return danhSachThiSinh.FirstOrDefault(ts => ts.SoBD == soBD);
         }
 
-        public bool CapNhatThiSinh(string soBD, ThongTinThiSinh thongTinCapNhat)
+        public bool CapNhatThiSinh(string soBD, Action<ThongTinThiSinh> capNhatAction)
         {
-            if (string.IsNullOrWhiteSpace(soBD) || thongTinCapNhat == null)
+            if (string.IsNullOrWhiteSpace(soBD) || capNhatAction == null)
             {
                 return false;
             }
@@ -68,57 +68,26 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                 return false;
             }
 
-            if (!string.Equals(thiSinhHienTai.SoBD, thongTinCapNhat.SoBD, StringComparison.Ordinal))
+            var soBDTruocKhiCapNhat = thiSinhHienTai.SoBD;
+
+            capNhatAction(thiSinhHienTai);
+
+            if (string.IsNullOrWhiteSpace(thiSinhHienTai.SoBD))
             {
-                var thiSinhTrung = TimTheoSoBD(thongTinCapNhat.SoBD);
-                if (thiSinhTrung != null && !ReferenceEquals(thiSinhTrung, thiSinhHienTai))
-                {
-                    return false;
-                }
-            }
-
-            if (thiSinhHienTai is ThiSinhKhoiA thiSinhKhoiA)
-            {
-                if (!(thongTinCapNhat is ThiSinhKhoiA capNhatKhoiA))
-                {
-                    return false;
-                }
-
-                CapNhatThongTinCoBan(thiSinhKhoiA, capNhatKhoiA);
-                CapNhatDiemKhoiA(thiSinhKhoiA, capNhatKhoiA);
-                return true;
-            }
-
-            if (thiSinhHienTai is ThiSinhKhoiB thiSinhKhoiB)
-            {
-                if (!(thongTinCapNhat is ThiSinhKhoiB capNhatKhoiB))
-                {
-                    return false;
-                }
-
-                CapNhatThongTinCoBan(thiSinhKhoiB, capNhatKhoiB);
-                CapNhatDiemKhoiB(thiSinhKhoiB, capNhatKhoiB);
-                return true;
-            }
-
-            if (thiSinhHienTai is ThiSinhKhoiC thiSinhKhoiC)
-            {
-                if (!(thongTinCapNhat is ThiSinhKhoiC capNhatKhoiC))
-                {
-                    return false;
-                }
-
-                CapNhatThongTinCoBan(thiSinhKhoiC, capNhatKhoiC);
-                CapNhatDiemKhoiC(thiSinhKhoiC, capNhatKhoiC);
-                return true;
-            }
-
-            if (thongTinCapNhat.GetType() != thiSinhHienTai.GetType())
-            {
+                thiSinhHienTai.SoBD = soBDTruocKhiCapNhat;
                 return false;
             }
 
-            CapNhatThongTinCoBan(thiSinhHienTai, thongTinCapNhat);
+            if (!string.Equals(soBDTruocKhiCapNhat, thiSinhHienTai.SoBD, StringComparison.Ordinal))
+            {
+                var thiSinhTrung = TimTheoSoBD(thiSinhHienTai.SoBD);
+                if (thiSinhTrung != null && !ReferenceEquals(thiSinhTrung, thiSinhHienTai))
+                {
+                    thiSinhHienTai.SoBD = soBDTruocKhiCapNhat;
+                    return false;
+                }
+            }
+
             return true;
         }
 
@@ -458,45 +427,6 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         private static string NormalizeText(string value)
         {
             return string.IsNullOrEmpty(value) ? string.Empty : value.Replace("|", "/");
-        }
-
-        private static void CapNhatThongTinCoBan(ThongTinThiSinh dich, ThongTinThiSinh nguon)
-        {
-            dich.SoBD = nguon.SoBD;
-            dich.HoTen = nguon.HoTen;
-            dich.NgaySinh = nguon.NgaySinh;
-            dich.DanToc = nguon.DanToc;
-            dich.TonGiao = nguon.TonGiao;
-            dich.GioiTinh = nguon.GioiTinh;
-            dich.NoiSinh = nguon.NoiSinh;
-            dich.DiaChi = nguon.DiaChi;
-            dich.SoCanCuoc = nguon.SoCanCuoc;
-            dich.SoDienThoai = nguon.SoDienThoai;
-            dich.Email = nguon.Email;
-            dich.KhuVuc = nguon.KhuVuc;
-            dich.DoiTuongUuTien = nguon.DoiTuongUuTien;
-            dich.HoiDongThi = nguon.HoiDongThi;
-        }
-
-        private static void CapNhatDiemKhoiA(ThiSinhKhoiA dich, ThiSinhKhoiA nguon)
-        {
-            dich.Diem.Toan = nguon.Diem.Toan;
-            dich.Diem.Ly = nguon.Diem.Ly;
-            dich.Diem.Hoa = nguon.Diem.Hoa;
-        }
-
-        private static void CapNhatDiemKhoiB(ThiSinhKhoiB dich, ThiSinhKhoiB nguon)
-        {
-            dich.Diem.Toan = nguon.Diem.Toan;
-            dich.Diem.Hoa = nguon.Diem.Hoa;
-            dich.Diem.Sinh = nguon.Diem.Sinh;
-        }
-
-        private static void CapNhatDiemKhoiC(ThiSinhKhoiC dich, ThiSinhKhoiC nguon)
-        {
-            dich.Diem.Van = nguon.Diem.Van;
-            dich.Diem.Su = nguon.Diem.Su;
-            dich.Diem.Dia = nguon.Diem.Dia;
         }
 
         private static NgayThangNam DocNgaySinhTuChuoi(string giaTri)

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -195,36 +197,472 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                 return;
             }
 
-            Console.WriteLine("Nhập thông tin mới cho thí sinh (các thông tin cũ sẽ được thay thế).");
+            bool daCapNhat = false;
+            bool tiepTuc = true;
 
-            ThongTinThiSinh thongTinCapNhat;
-            if (thiSinhHienTai is ThiSinhKhoiA)
+            while (tiepTuc)
             {
-                thongTinCapNhat = NhapThiSinhKhoiA();
+                HienThiMenuCapNhat(thiSinhHienTai);
+                Console.Write("Chọn mục cần cập nhật (0 để hoàn tất): ");
+                string luaChon = Console.ReadLine();
+                Console.WriteLine();
+
+                switch (luaChon)
+                {
+                    case "0":
+                        tiepTuc = false;
+                        break;
+                    case "1":
+                        CapNhatSoBaoDanh(ql, ref soBD, thiSinhHienTai, ref daCapNhat);
+                        break;
+                    case "2":
+                        {
+                            string hoTenMoi = NhapChuoiKhongRong("Nhập họ và tên mới: ");
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "họ và tên", ts => ts.HoTen = hoTenMoi);
+                            break;
+                        }
+                    case "3":
+                        {
+                            NgayThangNam ngaySinhMoi = NhapNgaySinhMoi();
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "ngày sinh", ts => ts.NgaySinh = ngaySinhMoi);
+                            break;
+                        }
+                    case "4":
+                        {
+                            string danTocMoi = NhapChuoiKhongRong("Nhập dân tộc mới: ");
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "dân tộc", ts => ts.DanToc = danTocMoi);
+                            break;
+                        }
+                    case "5":
+                        {
+                            string tonGiaoMoi = NhapChuoiKhongRong("Nhập tôn giáo mới: ");
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "tôn giáo", ts => ts.TonGiao = tonGiaoMoi);
+                            break;
+                        }
+                    case "6":
+                        {
+                            string gioiTinhMoi = NhapGioiTinhMoi();
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "giới tính", ts => ts.GioiTinh = gioiTinhMoi);
+                            break;
+                        }
+                    case "7":
+                        {
+                            string noiSinhMoi = NhapChuoiKhongRong("Nhập nơi sinh mới: ");
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "nơi sinh", ts => ts.NoiSinh = noiSinhMoi);
+                            break;
+                        }
+                    case "8":
+                        {
+                            string diaChiMoi = NhapChuoiKhongRong("Nhập địa chỉ mới: ");
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "địa chỉ", ts => ts.DiaChi = diaChiMoi);
+                            break;
+                        }
+                    case "9":
+                        {
+                            string soCanCuocMoi = NhapChuoiKhongRong("Nhập số căn cước mới: ");
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "số căn cước", ts => ts.SoCanCuoc = soCanCuocMoi);
+                            break;
+                        }
+                    case "10":
+                        {
+                            string soDienThoaiMoi = NhapSoDienThoaiMoi();
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "số điện thoại", ts => ts.SoDienThoai = soDienThoaiMoi);
+                            break;
+                        }
+                    case "11":
+                        {
+                            string emailMoi = NhapEmailMoi();
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "email", ts => ts.Email = emailMoi);
+                            break;
+                        }
+                    case "12":
+                        {
+                            string khuVucMoi = NhapKhuVucMoi();
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "khu vực", ts => ts.KhuVuc = khuVucMoi);
+                            break;
+                        }
+                    case "13":
+                        {
+                            int doiTuongMoi = NhapDoiTuongUuTienMoi();
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "đối tượng ưu tiên", ts => ts.DoiTuongUuTien = doiTuongMoi);
+                            break;
+                        }
+                    case "14":
+                        {
+                            string hoiDongMoi = NhapChuoiKhongRong("Nhập hội đồng thi mới: ");
+                            CapNhatGiaTri(ql, soBD, ref daCapNhat, "hội đồng thi", ts => ts.HoiDongThi = hoiDongMoi);
+                            break;
+                        }
+                        break;
+                    default:
+                        if (!CapNhatDiemThi(ql, ref soBD, thiSinhHienTai, luaChon, ref daCapNhat))
+                        {
+                            Console.WriteLine("Lựa chọn không hợp lệ. Vui lòng thử lại.");
+                        }
+                        break;
+                }
+
+                soBD = thiSinhHienTai.SoBD;
+                Console.WriteLine();
             }
-            else if (thiSinhHienTai is ThiSinhKhoiB)
+
+            if (daCapNhat)
             {
-                thongTinCapNhat = NhapThiSinhKhoiB();
-            }
-            else if (thiSinhHienTai is ThiSinhKhoiC)
-            {
-                thongTinCapNhat = NhapThiSinhKhoiC();
+                ql.LuuVaoTxt(filePath);
+                Console.WriteLine("Cập nhật thí sinh thành công.");
+                Console.WriteLine("Dữ liệu đã được lưu vào tệp.");
             }
             else
             {
-                Console.WriteLine("Loại thí sinh không xác định, không thể cập nhật.");
-                return;
+                Console.WriteLine("Không có thay đổi nào được thực hiện.");
             }
+        }
 
-            if (!ql.CapNhatThiSinh(soBD, thongTinCapNhat))
+        private static void CapNhatSoBaoDanh(QuanLyThiSinh ql, ref string soBD, ThongTinThiSinh thiSinhHienTai, ref bool daCapNhat)
+        {
+            string soBDMoi = NhapChuoiKhongRong("Nhập số báo danh mới: ");
+
+            if (!string.Equals(soBDMoi, thiSinhHienTai.SoBD, StringComparison.Ordinal))
             {
-                Console.WriteLine("Cập nhật thất bại. Có thể số báo danh mới đã tồn tại hoặc loại khối không khớp.");
+                var thiSinhTrung = ql.TimTheoSoBD(soBDMoi);
+                if (thiSinhTrung != null && !ReferenceEquals(thiSinhTrung, thiSinhHienTai))
+                {
+                    Console.WriteLine("Số báo danh đã tồn tại. Vui lòng chọn số khác.");
+                    return;
+                }
+            }
+
+            if (ql.CapNhatThiSinh(soBD, ts => ts.SoBD = soBDMoi))
+            {
+                daCapNhat = true;
+                soBD = thiSinhHienTai.SoBD;
+                Console.WriteLine("Đã cập nhật số báo danh.");
+            }
+            else
+            {
+                Console.WriteLine("Cập nhật số báo danh thất bại.");
+            }
+        }
+
+        private static void CapNhatGiaTri(QuanLyThiSinh ql, string soBD, ref bool daCapNhat, string moTaThongTin, Action<ThongTinThiSinh> capNhat)
+        {
+            if (capNhat == null)
+            {
                 return;
             }
 
-            Console.WriteLine("Cập nhật thí sinh thành công.");
-            ql.LuuVaoTxt(filePath);
-            Console.WriteLine("Dữ liệu đã được lưu vào tệp.");
+            if (ql.CapNhatThiSinh(soBD, capNhat))
+            {
+                daCapNhat = true;
+                Console.WriteLine($"Đã cập nhật {moTaThongTin}.");
+            }
+            else
+            {
+                Console.WriteLine($"Cập nhật {moTaThongTin} không thành công.");
+            }
+        }
+
+        private static bool CapNhatDiemThi(QuanLyThiSinh ql, ref string soBD, ThongTinThiSinh thiSinhHienTai, string luaChon, ref bool daCapNhat)
+        {
+            switch (thiSinhHienTai)
+            {
+                case ThiSinhKhoiA thiSinhKhoiA:
+                    return CapNhatDiemKhoiA(ql, soBD, thiSinhKhoiA, luaChon, ref daCapNhat);
+                case ThiSinhKhoiB thiSinhKhoiB:
+                    return CapNhatDiemKhoiB(ql, soBD, thiSinhKhoiB, luaChon, ref daCapNhat);
+                case ThiSinhKhoiC thiSinhKhoiC:
+                    return CapNhatDiemKhoiC(ql, soBD, thiSinhKhoiC, luaChon, ref daCapNhat);
+            }
+
+            return false;
+        }
+
+        private static bool CapNhatDiemKhoiA(QuanLyThiSinh ql, string soBD, ThiSinhKhoiA thiSinh, string luaChon, ref bool daCapNhat)
+        {
+            switch (luaChon)
+            {
+                case "15":
+                    return CapNhatDiemMon(ql, soBD, ref daCapNhat, "Toán", diem => thiSinh.Diem.Toan = diem);
+                case "16":
+                    return CapNhatDiemMon(ql, soBD, ref daCapNhat, "Lý", diem => thiSinh.Diem.Ly = diem);
+                case "17":
+                    return CapNhatDiemMon(ql, soBD, ref daCapNhat, "Hóa", diem => thiSinh.Diem.Hoa = diem);
+            }
+
+            return false;
+        }
+
+        private static bool CapNhatDiemKhoiB(QuanLyThiSinh ql, string soBD, ThiSinhKhoiB thiSinh, string luaChon, ref bool daCapNhat)
+        {
+            switch (luaChon)
+            {
+                case "15":
+                    return CapNhatDiemMon(ql, soBD, ref daCapNhat, "Toán", diem => thiSinh.Diem.Toan = diem);
+                case "16":
+                    return CapNhatDiemMon(ql, soBD, ref daCapNhat, "Hóa", diem => thiSinh.Diem.Hoa = diem);
+                case "17":
+                    return CapNhatDiemMon(ql, soBD, ref daCapNhat, "Sinh", diem => thiSinh.Diem.Sinh = diem);
+            }
+
+            return false;
+        }
+
+        private static bool CapNhatDiemKhoiC(QuanLyThiSinh ql, string soBD, ThiSinhKhoiC thiSinh, string luaChon, ref bool daCapNhat)
+        {
+            switch (luaChon)
+            {
+                case "15":
+                    return CapNhatDiemMon(ql, soBD, ref daCapNhat, "Văn", diem => thiSinh.Diem.Van = diem);
+                case "16":
+                    return CapNhatDiemMon(ql, soBD, ref daCapNhat, "Sử", diem => thiSinh.Diem.Su = diem);
+                case "17":
+                    return CapNhatDiemMon(ql, soBD, ref daCapNhat, "Địa", diem => thiSinh.Diem.Dia = diem);
+            }
+
+            return false;
+        }
+
+        private static bool CapNhatDiemMon(QuanLyThiSinh ql, string soBD, ref bool daCapNhat, string tenMon, Action<double> ganDiem)
+        {
+            double diemMoi = NhapDiemMon(tenMon);
+
+            if (ql.CapNhatThiSinh(soBD, _ => ganDiem(diemMoi)))
+            {
+                daCapNhat = true;
+                Console.WriteLine($"Đã cập nhật điểm {tenMon}.");
+                return true;
+            }
+
+            Console.WriteLine($"Cập nhật điểm {tenMon} thất bại.");
+            return false;
+        }
+
+        private static void HienThiMenuCapNhat(ThongTinThiSinh thiSinh)
+        {
+            Console.WriteLine("===== THÔNG TIN HIỆN TẠI =====");
+            Console.WriteLine($"1. Số báo danh     : {thiSinh.SoBD}");
+            Console.WriteLine($"2. Họ và tên       : {thiSinh.HoTen}");
+            Console.WriteLine($"3. Ngày sinh       : {thiSinh.NgaySinh}");
+            Console.WriteLine($"4. Dân tộc         : {thiSinh.DanToc}");
+            Console.WriteLine($"5. Tôn giáo        : {thiSinh.TonGiao}");
+            Console.WriteLine($"6. Giới tính       : {thiSinh.GioiTinh}");
+            Console.WriteLine($"7. Nơi sinh        : {thiSinh.NoiSinh}");
+            Console.WriteLine($"8. Địa chỉ         : {thiSinh.DiaChi}");
+            Console.WriteLine($"9. Số căn cước     : {thiSinh.SoCanCuoc}");
+            Console.WriteLine($"10. Số điện thoại  : {thiSinh.SoDienThoai}");
+            Console.WriteLine($"11. Email          : {thiSinh.Email}");
+            Console.WriteLine($"12. Khu vực        : {thiSinh.KhuVuc}");
+            Console.WriteLine($"13. Đối tượng UT   : {thiSinh.DoiTuongUuTien}");
+            Console.WriteLine($"14. Hội đồng thi   : {thiSinh.HoiDongThi}");
+
+            if (thiSinh is ThiSinhKhoiA khoiA)
+            {
+                Console.WriteLine($"15. Điểm Toán      : {khoiA.Diem.Toan}");
+                Console.WriteLine($"16. Điểm Lý        : {khoiA.Diem.Ly}");
+                Console.WriteLine($"17. Điểm Hóa       : {khoiA.Diem.Hoa}");
+            }
+            else if (thiSinh is ThiSinhKhoiB khoiB)
+            {
+                Console.WriteLine($"15. Điểm Toán      : {khoiB.Diem.Toan}");
+                Console.WriteLine($"16. Điểm Hóa       : {khoiB.Diem.Hoa}");
+                Console.WriteLine($"17. Điểm Sinh      : {khoiB.Diem.Sinh}");
+            }
+            else if (thiSinh is ThiSinhKhoiC khoiC)
+            {
+                Console.WriteLine($"15. Điểm Văn       : {khoiC.Diem.Van}");
+                Console.WriteLine($"16. Điểm Sử        : {khoiC.Diem.Su}");
+                Console.WriteLine($"17. Điểm Địa       : {khoiC.Diem.Dia}");
+            }
+
+            Console.WriteLine("0. Hoàn tất cập nhật");
+            Console.WriteLine();
+        }
+
+        private static NgayThangNam NhapNgaySinhMoi()
+        {
+            while (true)
+            {
+                Console.Write("Nhập ngày sinh mới (dd/mm/yyyy): ");
+                string giaTri = Console.ReadLine();
+
+                if (string.IsNullOrWhiteSpace(giaTri))
+                {
+                    Console.WriteLine("Ngày sinh không được để trống.");
+                    continue;
+                }
+
+                var parts = giaTri
+                    .Split(new[] { '/', '-', '.', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                if (parts.Length != 3)
+                {
+                    Console.WriteLine("Định dạng ngày sinh không hợp lệ. Vui lòng nhập lại.");
+                    continue;
+                }
+
+                if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var ngay) ||
+                    !int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var thang) ||
+                    !int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var nam))
+                {
+                    Console.WriteLine("Ngày sinh chỉ được phép chứa số.");
+                    continue;
+                }
+
+                try
+                {
+                    return new NgayThangNam(ngay, thang, nam);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    Console.WriteLine("Ngày sinh không hợp lệ. Vui lòng nhập lại.");
+                }
+            }
+        }
+
+        private static string NhapChuoiKhongRong(string thongDiep)
+        {
+            while (true)
+            {
+                Console.Write(thongDiep);
+                string giaTri = Console.ReadLine();
+
+                if (!string.IsNullOrWhiteSpace(giaTri))
+                {
+                    return giaTri.Trim();
+                }
+
+                Console.WriteLine("Giá trị không được để trống.");
+            }
+        }
+
+        private static string NhapGioiTinhMoi()
+        {
+            while (true)
+            {
+                Console.Write("Nhập giới tính mới (Nam/Nữ): ");
+                string gioiTinh = Console.ReadLine();
+
+                if (string.IsNullOrWhiteSpace(gioiTinh))
+                {
+                    Console.WriteLine("Giới tính không được để trống.");
+                    continue;
+                }
+
+                gioiTinh = gioiTinh.Trim();
+                if (string.Equals(gioiTinh, "Nam", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(gioiTinh, "Nữ", StringComparison.OrdinalIgnoreCase))
+                {
+                    TextInfo textInfo = CultureInfo.CurrentCulture.TextInfo;
+                    return textInfo.ToTitleCase(gioiTinh.ToLowerInvariant());
+                }
+
+                Console.WriteLine("Giới tính chỉ được nhập Nam hoặc Nữ.");
+            }
+        }
+
+        private static string NhapSoDienThoaiMoi()
+        {
+            while (true)
+            {
+                Console.Write("Nhập số điện thoại mới (10-11 số): ");
+                string soDienThoai = Console.ReadLine();
+
+                if (!string.IsNullOrWhiteSpace(soDienThoai) &&
+                    soDienThoai.Length >= 10 &&
+                    soDienThoai.Length <= 11 &&
+                    long.TryParse(soDienThoai, out _))
+                {
+                    return soDienThoai;
+                }
+
+                Console.WriteLine("Số điện thoại không hợp lệ. Vui lòng nhập lại.");
+            }
+        }
+
+        private static string NhapEmailMoi()
+        {
+            while (true)
+            {
+                Console.Write("Nhập email mới: ");
+                string email = Console.ReadLine();
+
+                if (!string.IsNullOrWhiteSpace(email) && email.Contains("@") && email.Contains("."))
+                {
+                    return email.Trim();
+                }
+
+                Console.WriteLine("Email không hợp lệ. Vui lòng nhập lại.");
+            }
+        }
+
+        private static string NhapKhuVucMoi()
+        {
+            HashSet<string> khuVucHopLe = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "KV1",
+                "KV2",
+                "KV2-NT",
+                "KV3"
+            };
+
+            while (true)
+            {
+                Console.Write("Nhập khu vực mới (KV1/KV2/KV2-NT/KV3): ");
+                string khuVuc = Console.ReadLine();
+
+                if (!string.IsNullOrWhiteSpace(khuVuc))
+                {
+                    khuVuc = khuVuc.Trim().ToUpperInvariant();
+                    if (khuVucHopLe.Contains(khuVuc))
+                    {
+                        return khuVuc;
+                    }
+                }
+
+                Console.WriteLine("Khu vực không hợp lệ. Vui lòng nhập lại.");
+            }
+        }
+
+        private static int NhapDoiTuongUuTienMoi()
+        {
+            while (true)
+            {
+                Console.Write("Nhập đối tượng ưu tiên mới (0/1/2): ");
+                string giaTri = Console.ReadLine();
+
+                if (int.TryParse(giaTri, NumberStyles.Integer, CultureInfo.InvariantCulture, out var doiTuong) &&
+                    doiTuong >= 0 && doiTuong <= 2)
+                {
+                    return doiTuong;
+                }
+
+                Console.WriteLine("Đối tượng ưu tiên không hợp lệ. Vui lòng nhập lại.");
+            }
+        }
+
+        private static double NhapDiemMon(string tenMon)
+        {
+            while (true)
+            {
+                Console.Write($"Nhập điểm {tenMon} (0-10): ");
+                string giaTri = Console.ReadLine();
+
+                if (string.IsNullOrWhiteSpace(giaTri))
+                {
+                    Console.WriteLine("Điểm không được để trống.");
+                    continue;
+                }
+
+                giaTri = giaTri.Replace(',', '.');
+
+                if (double.TryParse(giaTri, NumberStyles.Number, CultureInfo.InvariantCulture, out var diem) &&
+                    diem >= 0 && diem <= 10)
+                {
+                    return diem;
+                }
+
+                Console.WriteLine("Điểm không hợp lệ. Vui lòng nhập lại.");
+            }
         }
 
         private static void XoaThiSinh(QuanLyThiSinh ql, string filePath)


### PR DESCRIPTION
## Summary
- allow updating individual candidate fields without re-entering all data
- add validation helpers for editing personal information and scores
- adjust management layer to support targeted update actions with duplicate safeguards

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de14f222808322b3bc2d03eacd0857