### PR TITLE
Refactor exam score handling with shared base class

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
@@ -2,34 +2,17 @@ using System;
 
 namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
-    public class DiemKhoiA : IDiemThi
+    public class DiemKhoiA : DiemThiBase
     {
         public double Toan { get; set; }
         public double Ly { get; set; }
         public double Hoa { get; set; }
 
-        public void NhapDiem()
+        protected override (string TenMon, Func<double> Getter, Action<double> Setter)[] MonHoc => new[]
         {
-            Toan = NhapDiemMon("Toán");
-            Ly = NhapDiemMon("Lý");
-            Hoa = NhapDiemMon("Hóa");
-        }
-
-        public void InDiem()
-        {
-            Console.WriteLine($"Toán: {Toan} | Lý: {Ly} | Hóa: {Hoa}");
-        }
-
-        private static double NhapDiemMon(string tenMon)
-        {
-            double diem;
-            Console.Write($"Nhập điểm {tenMon}: ");
-            while (!double.TryParse(Console.ReadLine(), out diem) || diem < 0 || diem > 10)
-            {
-                Console.Write($"Điểm không hợp lệ! Nhập lại điểm {tenMon} (0-10): ");
-            }
-
-            return Math.Round(diem, 2);
-        }
+            ("Toán", () => Toan, value => Toan = value),
+            ("Lý", () => Ly, value => Ly = value),
+            ("Hóa", () => Hoa, value => Hoa = value),
+        };
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
@@ -2,34 +2,17 @@ using System;
 
 namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
-    public class DiemKhoiB : IDiemThi
+    public class DiemKhoiB : DiemThiBase
     {
         public double Toan { get; set; }
         public double Hoa { get; set; }
         public double Sinh { get; set; }
 
-        public void NhapDiem()
+        protected override (string TenMon, Func<double> Getter, Action<double> Setter)[] MonHoc => new[]
         {
-            Toan = NhapDiemMon("Toán");
-            Hoa = NhapDiemMon("Hóa");
-            Sinh = NhapDiemMon("Sinh");
-        }
-
-        public void InDiem()
-        {
-            Console.WriteLine($"Toán: {Toan} | Hóa: {Hoa} | Sinh: {Sinh}");
-        }
-
-        private static double NhapDiemMon(string tenMon)
-        {
-            double diem;
-            Console.Write($"Nhập điểm {tenMon}: ");
-            while (!double.TryParse(Console.ReadLine(), out diem) || diem < 0 || diem > 10)
-            {
-                Console.Write($"Điểm không hợp lệ! Nhập lại điểm {tenMon} (0-10): ");
-            }
-
-            return Math.Round(diem, 2);
-        }
+            ("Toán", () => Toan, value => Toan = value),
+            ("Hóa", () => Hoa, value => Hoa = value),
+            ("Sinh", () => Sinh, value => Sinh = value),
+        };
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
@@ -2,34 +2,17 @@ using System;
 
 namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
-    public class DiemKhoiC : IDiemThi
+    public class DiemKhoiC : DiemThiBase
     {
         public double Van { get; set; }
         public double Su { get; set; }
         public double Dia { get; set; }
 
-        public void NhapDiem()
+        protected override (string TenMon, Func<double> Getter, Action<double> Setter)[] MonHoc => new[]
         {
-            Van = NhapDiemMon("Văn");
-            Su = NhapDiemMon("Sử");
-            Dia = NhapDiemMon("Địa");
-        }
-
-        public void InDiem()
-        {
-            Console.WriteLine($"Văn: {Van} | Sử: {Su} | Địa: {Dia}");
-        }
-
-        private static double NhapDiemMon(string tenMon)
-        {
-            double diem;
-            Console.Write($"Nhập điểm {tenMon}: ");
-            while (!double.TryParse(Console.ReadLine(), out diem) || diem < 0 || diem > 10)
-            {
-                Console.Write($"Điểm không hợp lệ! Nhập lại điểm {tenMon} (0-10): ");
-            }
-
-            return Math.Round(diem, 2);
-        }
+            ("Văn", () => Van, value => Van = value),
+            ("Sử", () => Su, value => Su = value),
+            ("Địa", () => Dia, value => Dia = value),
+        };
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBase.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBase.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
+{
+    public abstract class DiemThiBase : IDiemThi
+    {
+        protected abstract (string TenMon, Func<double> Getter, Action<double> Setter)[] MonHoc { get; }
+
+        public void NhapDiem()
+        {
+            foreach (var mon in MonHoc)
+            {
+                var diem = NhapDiemMon(mon.TenMon);
+                mon.Setter(diem);
+            }
+        }
+
+        public void InDiem()
+        {
+            var monHoc = MonHoc;
+            var thongTin = string.Join(" | ", Array.ConvertAll(monHoc, mon => $"{mon.TenMon}: {mon.Getter()}"));
+            Console.WriteLine(thongTin);
+        }
+
+        protected static double NhapDiemMon(string tenMon)
+        {
+            double diem;
+            Console.Write($"Nhập điểm {tenMon}: ");
+            while (!double.TryParse(Console.ReadLine(), out diem) || diem < 0 || diem > 10)
+            {
+                Console.Write($"Điểm không hợp lệ! Nhập lại điểm {tenMon} (0-10): ");
+            }
+
+            return Math.Round(diem, 2);
+        }
+    }
+}

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.csproj
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.csproj
@@ -47,6 +47,7 @@
     <Compile Include="%28Diem%29DiemKhoiA.cs" />
     <Compile Include="%28Diem%29DiemKhoiB.cs" />
     <Compile Include="%28Diem%29DiemKhoiC.cs" />
+    <Compile Include="%28Diem%29DiemThiBase.cs" />
     <Compile Include="%28TS%29IThiKhoi.cs" />
     <Compile Include="%28Diem%29IDiemThi.cs" />
     <Compile Include="Program.cs" />


### PR DESCRIPTION
## Summary
- add an abstract `DiemThiBase` that centralizes subject descriptors and shared input/output logic for exam scores
- update the block-specific score classes to inherit from the base class and declare their subject tuples while keeping existing properties intact
- include the new source file in the project so it is compiled with the rest of the application

## Testing
- `dotnet build Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.sln` *(fails: `dotnet` CLI not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de30f5ec108322856e5279823bbd5f