### PR TITLE
Ensure UTF-8 BOM when exporting candidates

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -201,7 +201,8 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                     "Mon1", "Mon2", "Mon3"
                 };
 
-                using (var writer = new StreamWriter(filePath, false, Encoding.UTF8))
+                // Ghi kèm BOM để Notepad và các trình soạn thảo tương tự hiển thị đúng chữ có dấu.
+                using (var writer = new StreamWriter(filePath, false, new UTF8Encoding(true)))
                 {
                     writer.WriteLine(string.Join("|", headers));
 


### PR DESCRIPTION
## Summary
- ensure the text export writes UTF-8 with BOM so editors like Notepad show accented characters correctly
- document the requirement with an inline comment to avoid reverting the change later

## Testing
- not run (not applicable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68de33a8b9f883229b80621fe2522620