### PR TITLE
Refactor mon descriptor handling

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
@@ -8,11 +8,17 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public double Ly { get; set; }
         public double Hoa { get; set; }
 
-        protected override (string TenMon, Func<double> Getter, Action<double> Setter)[] MonHoc => new[]
+        protected override MonHocDescriptor[] MonHoc
         {
-            ("Toán", () => Toan, value => Toan = value),
-            ("Lý", () => Ly, value => Ly = value),
-            ("Hóa", () => Hoa, value => Hoa = value),
-        };
+            get
+            {
+                return new MonHocDescriptor[]
+                {
+                    new MonHocDescriptor("Toán", () => Toan, value => Toan = value),
+                    new MonHocDescriptor("Lý", () => Ly, value => Ly = value),
+                    new MonHocDescriptor("Hóa", () => Hoa, value => Hoa = value),
+                };
+            }
+        }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
@@ -8,11 +8,17 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public double Hoa { get; set; }
         public double Sinh { get; set; }
 
-        protected override (string TenMon, Func<double> Getter, Action<double> Setter)[] MonHoc => new[]
+        protected override MonHocDescriptor[] MonHoc
         {
-            ("Toán", () => Toan, value => Toan = value),
-            ("Hóa", () => Hoa, value => Hoa = value),
-            ("Sinh", () => Sinh, value => Sinh = value),
-        };
+            get
+            {
+                return new MonHocDescriptor[]
+                {
+                    new MonHocDescriptor("Toán", () => Toan, value => Toan = value),
+                    new MonHocDescriptor("Hóa", () => Hoa, value => Hoa = value),
+                    new MonHocDescriptor("Sinh", () => Sinh, value => Sinh = value),
+                };
+            }
+        }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
@@ -8,11 +8,17 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public double Su { get; set; }
         public double Dia { get; set; }
 
-        protected override (string TenMon, Func<double> Getter, Action<double> Setter)[] MonHoc => new[]
+        protected override MonHocDescriptor[] MonHoc
         {
-            ("Văn", () => Van, value => Van = value),
-            ("Sử", () => Su, value => Su = value),
-            ("Địa", () => Dia, value => Dia = value),
-        };
+            get
+            {
+                return new MonHocDescriptor[]
+                {
+                    new MonHocDescriptor("Văn", () => Van, value => Van = value),
+                    new MonHocDescriptor("Sử", () => Su, value => Su = value),
+                    new MonHocDescriptor("Địa", () => Dia, value => Dia = value),
+                };
+            }
+        }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBase.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBase.cs
@@ -4,7 +4,21 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
     public abstract class DiemThiBase : IDiemThi
     {
-        protected abstract (string TenMon, Func<double> Getter, Action<double> Setter)[] MonHoc { get; }
+        protected class MonHocDescriptor
+        {
+            public MonHocDescriptor(string tenMon, Func<double> getter, Action<double> setter)
+            {
+                TenMon = tenMon;
+                Getter = getter;
+                Setter = setter;
+            }
+
+            public string TenMon { get; }
+            public Func<double> Getter { get; }
+            public Action<double> Setter { get; }
+        }
+
+        protected abstract MonHocDescriptor[] MonHoc { get; }
 
         public void NhapDiem()
         {


### PR DESCRIPTION
## Summary
- introduce a `MonHocDescriptor` helper class to encapsulate subject metadata
- update the base and block-specific score classes to use the descriptor helper

## Testing
- Not run (dotnet/msbuild not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de36c66e908322a84971acd65dd4fe