### PR TITLE
Prevent duplicate SoBD during candidate updates

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -80,8 +80,8 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
             if (!string.Equals(soBDTruocKhiCapNhat, thiSinhHienTai.SoBD, StringComparison.Ordinal))
             {
-                var thiSinhTrung = TimTheoSoBD(thiSinhHienTai.SoBD);
-                if (thiSinhTrung != null && !ReferenceEquals(thiSinhTrung, thiSinhHienTai))
+                var coSoBDTrung = danhSachThiSinh.Any(ts => !ReferenceEquals(ts, thiSinhHienTai) && ts.SoBD == thiSinhHienTai.SoBD);
+                if (coSoBDTrung)
                 {
                     thiSinhHienTai.SoBD = soBDTruocKhiCapNhat;
                     return false;


### PR DESCRIPTION
## Summary
- ensure the candidate list checks for duplicate exam IDs using a direct Any lookup when updating
- restore the original exam ID and reject the update if the new ID conflicts with another candidate

## Testing
- Manual reasoning through update scenarios

------
https://chatgpt.com/codex/tasks/task_e_68de855ab4288322bdde8e1f2d6c067f