### PR TITLE
Ensure search results use block-specific printing

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
@@ -285,8 +285,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             Console.WriteLine("===== KẾT QUẢ TÌM KIẾM =====");
             foreach (var ts in ketQua)
             {
-                ts.InThongTin();
-                Console.WriteLine();
+                InThongTinThiSinhDayDu(ts);
             }
         }
 
@@ -310,7 +309,25 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             }
 
             Console.WriteLine("===== KẾT QUẢ TÌM KIẾM =====");
-            thiSinh.InThongTin();
+            InThongTinThiSinhDayDu(thiSinh);
+        }
+
+        private static void InThongTinThiSinhDayDu(ThongTinThiSinh thiSinh)
+        {
+            if (thiSinh == null)
+            {
+                return;
+            }
+
+            if (thiSinh is IThiKhoi thiKhoi)
+            {
+                thiKhoi.In();
+            }
+            else
+            {
+                thiSinh.InThongTin();
+            }
+
             Console.WriteLine();
         }
 


### PR DESCRIPTION
## Summary
- add a helper in Program to print candidates via IThiKhoi when available
- update name and ID search flows to reuse the helper for consistent output

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dea9c2f1008322979e215d52347521