### PR TITLE
Đổi tên hàm sang tiếng Việt

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
@@ -8,15 +8,15 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public double Ly { get; set; }
         public double Hoa { get; set; }
 
-        protected override MonHocDescriptor[] MonHoc
+        protected override MoTaMonHoc[] DanhSachMonHoc
         {
             get
             {
-                return new MonHocDescriptor[]
+                return new MoTaMonHoc[]
                 {
-                    new MonHocDescriptor("Toán", () => Toan, value => Toan = value),
-                    new MonHocDescriptor("Lý", () => Ly, value => Ly = value),
-                    new MonHocDescriptor("Hóa", () => Hoa, value => Hoa = value),
+                    new MoTaMonHoc("Toán", () => Toan, value => Toan = value),
+                    new MoTaMonHoc("Lý", () => Ly, value => Ly = value),
+                    new MoTaMonHoc("Hóa", () => Hoa, value => Hoa = value),
                 };
             }
         }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
@@ -8,15 +8,15 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public double Hoa { get; set; }
         public double Sinh { get; set; }
 
-        protected override MonHocDescriptor[] MonHoc
+        protected override MoTaMonHoc[] DanhSachMonHoc
         {
             get
             {
-                return new MonHocDescriptor[]
+                return new MoTaMonHoc[]
                 {
-                    new MonHocDescriptor("Toán", () => Toan, value => Toan = value),
-                    new MonHocDescriptor("Hóa", () => Hoa, value => Hoa = value),
-                    new MonHocDescriptor("Sinh", () => Sinh, value => Sinh = value),
+                    new MoTaMonHoc("Toán", () => Toan, value => Toan = value),
+                    new MoTaMonHoc("Hóa", () => Hoa, value => Hoa = value),
+                    new MoTaMonHoc("Sinh", () => Sinh, value => Sinh = value),
                 };
             }
         }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
@@ -8,15 +8,15 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public double Su { get; set; }
         public double Dia { get; set; }
 
-        protected override MonHocDescriptor[] MonHoc
+        protected override MoTaMonHoc[] DanhSachMonHoc
         {
             get
             {
-                return new MonHocDescriptor[]
+                return new MoTaMonHoc[]
                 {
-                    new MonHocDescriptor("Văn", () => Van, value => Van = value),
-                    new MonHocDescriptor("Sử", () => Su, value => Su = value),
-                    new MonHocDescriptor("Địa", () => Dia, value => Dia = value),
+                    new MoTaMonHoc("Văn", () => Van, value => Van = value),
+                    new MoTaMonHoc("Sử", () => Su, value => Su = value),
+                    new MoTaMonHoc("Địa", () => Dia, value => Dia = value),
                 };
             }
         }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBase.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBase.cs
@@ -4,35 +4,35 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
     public abstract class DiemThiBase : IDiemThi
     {
-        protected class MonHocDescriptor
+        protected class MoTaMonHoc
         {
-            public MonHocDescriptor(string tenMon, Func<double> getter, Action<double> setter)
+            public MoTaMonHoc(string tenMon, Func<double> layGiaTri, Action<double> ganGiaTri)
             {
                 TenMon = tenMon;
-                Getter = getter;
-                Setter = setter;
+                LayGiaTri = layGiaTri;
+                GanGiaTri = ganGiaTri;
             }
 
             public string TenMon { get; }
-            public Func<double> Getter { get; }
-            public Action<double> Setter { get; }
+            public Func<double> LayGiaTri { get; }
+            public Action<double> GanGiaTri { get; }
         }
 
-        protected abstract MonHocDescriptor[] MonHoc { get; }
+        protected abstract MoTaMonHoc[] DanhSachMonHoc { get; }
 
         public void NhapDiem()
         {
-            foreach (var mon in MonHoc)
+            foreach (var mon in DanhSachMonHoc)
             {
                 var diem = NhapDiemMon(mon.TenMon);
-                mon.Setter(diem);
+                mon.GanGiaTri(diem);
             }
         }
 
         public void InDiem()
         {
-            var monHoc = MonHoc;
-            var thongTin = string.Join(" | ", Array.ConvertAll(monHoc, mon => $"{mon.TenMon}: {mon.Getter()}"));
+            var monHoc = DanhSachMonHoc;
+            var thongTin = string.Join(" | ", Array.ConvertAll(monHoc, mon => $"{mon.TenMon}: {mon.LayGiaTri()}"));
             Console.WriteLine(thongTin);
         }
 

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)QuanLyThiSinh.cs
@@ -9,7 +9,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
     public class QuanLyThiSinh
     {
         private List<ThongTinThiSinh> danhSachThiSinh;
-        private const string FileStructureGuidance = "Định dạng tệp:\n" +
+        private const string HuongDanCauTrucFile = "Định dạng tệp:\n" +
             "Khoi|SoBD|HoTen|NgaySinh|DanToc|TonGiao|GioiTinh|NoiSinh|DiaChi|SoCanCuoc|SoDienThoai|Email|KhuVuc|DoiTuongUuTien|HoiDongThi|Mon1|Mon2|Mon3\n" +
             "Khối A: Mon1=Toán, Mon2=Lý, Mon3=Hóa\n" +
             "Khối B: Mon1=Toán, Mon2=Hóa, Mon3=Sinh\n" +
@@ -239,20 +239,20 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                             _ => string.Empty
                         };
 
-                        fields[1] = NormalizeText(ts.SoBD);
-                        fields[2] = NormalizeText(ts.HoTen);
+                        fields[1] = ChuanHoaChuoi(ts.SoBD);
+                        fields[2] = ChuanHoaChuoi(ts.HoTen);
                         fields[3] = ts.NgaySinh.ToString();
-                        fields[4] = NormalizeText(ts.DanToc);
-                        fields[5] = NormalizeText(ts.TonGiao);
-                        fields[6] = NormalizeText(ts.GioiTinh);
-                        fields[7] = NormalizeText(ts.NoiSinh);
-                        fields[8] = NormalizeText(ts.DiaChi);
-                        fields[9] = NormalizeText(ts.SoCanCuoc);
-                        fields[10] = NormalizeText(ts.SoDienThoai);
-                        fields[11] = NormalizeText(ts.Email);
-                        fields[12] = NormalizeText(ts.KhuVuc);
+                        fields[4] = ChuanHoaChuoi(ts.DanToc);
+                        fields[5] = ChuanHoaChuoi(ts.TonGiao);
+                        fields[6] = ChuanHoaChuoi(ts.GioiTinh);
+                        fields[7] = ChuanHoaChuoi(ts.NoiSinh);
+                        fields[8] = ChuanHoaChuoi(ts.DiaChi);
+                        fields[9] = ChuanHoaChuoi(ts.SoCanCuoc);
+                        fields[10] = ChuanHoaChuoi(ts.SoDienThoai);
+                        fields[11] = ChuanHoaChuoi(ts.Email);
+                        fields[12] = ChuanHoaChuoi(ts.KhuVuc);
                         fields[13] = ts.DoiTuongUuTien.ToString(CultureInfo.InvariantCulture);
-                        fields[14] = NormalizeText(ts.HoiDongThi);
+                        fields[14] = ChuanHoaChuoi(ts.HoiDongThi);
 
                         double? mon1 = null;
                         double? mon2 = null;
@@ -277,9 +277,9 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                                 break;
                         }
 
-                        fields[15] = FormatScore(mon1);
-                        fields[16] = FormatScore(mon2);
-                        fields[17] = FormatScore(mon3);
+                        fields[15] = DinhDangDiemSo(mon1);
+                        fields[16] = DinhDangDiemSo(mon2);
+                        fields[17] = DinhDangDiemSo(mon3);
 
                         writer.WriteLine(string.Join("|", fields));
                     }
@@ -386,23 +386,23 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
                             {
                                 case "A":
                                     var thiSinhA = new ThiSinhKhoiA();
-                                    thiSinhA.Diem.Toan = ParseDiem(parts[15], "điểm Toán", khoiTrim);
-                                    thiSinhA.Diem.Ly = ParseDiem(parts[16], "điểm Lý", khoiTrim);
-                                    thiSinhA.Diem.Hoa = ParseDiem(parts[17], "điểm Hóa", khoiTrim);
+                                    thiSinhA.Diem.Toan = PhanTichDiem(parts[15], "điểm Toán", khoiTrim);
+                                    thiSinhA.Diem.Ly = PhanTichDiem(parts[16], "điểm Lý", khoiTrim);
+                                    thiSinhA.Diem.Hoa = PhanTichDiem(parts[17], "điểm Hóa", khoiTrim);
                                     thiSinh = thiSinhA;
                                     break;
                                 case "B":
                                     var thiSinhB = new ThiSinhKhoiB();
-                                    thiSinhB.Diem.Toan = ParseDiem(parts[15], "điểm Toán", khoiTrim);
-                                    thiSinhB.Diem.Hoa = ParseDiem(parts[16], "điểm Hóa", khoiTrim);
-                                    thiSinhB.Diem.Sinh = ParseDiem(parts[17], "điểm Sinh", khoiTrim);
+                                    thiSinhB.Diem.Toan = PhanTichDiem(parts[15], "điểm Toán", khoiTrim);
+                                    thiSinhB.Diem.Hoa = PhanTichDiem(parts[16], "điểm Hóa", khoiTrim);
+                                    thiSinhB.Diem.Sinh = PhanTichDiem(parts[17], "điểm Sinh", khoiTrim);
                                     thiSinh = thiSinhB;
                                     break;
                                 case "C":
                                     var thiSinhC = new ThiSinhKhoiC();
-                                    thiSinhC.Diem.Van = ParseDiem(parts[15], "điểm Văn", khoiTrim);
-                                    thiSinhC.Diem.Su = ParseDiem(parts[16], "điểm Sử", khoiTrim);
-                                    thiSinhC.Diem.Dia = ParseDiem(parts[17], "điểm Địa", khoiTrim);
+                                    thiSinhC.Diem.Van = PhanTichDiem(parts[15], "điểm Văn", khoiTrim);
+                                    thiSinhC.Diem.Su = PhanTichDiem(parts[16], "điểm Sử", khoiTrim);
+                                    thiSinhC.Diem.Dia = PhanTichDiem(parts[17], "điểm Địa", khoiTrim);
                                     thiSinh = thiSinhC;
                                     break;
                                 default:
@@ -441,12 +441,12 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             }
         }
 
-        private static string FormatScore(double? score)
+        private static string DinhDangDiemSo(double? score)
         {
             return score.HasValue ? score.Value.ToString(CultureInfo.InvariantCulture) : string.Empty;
         }
 
-        private static string NormalizeText(string value)
+        private static string ChuanHoaChuoi(string value)
         {
             return string.IsNullOrEmpty(value) ? string.Empty : value.Replace("|", "/");
         }
@@ -482,11 +482,11 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             }
         }
 
-        private static double ParseDiem(string giaTri, string tenMon, string khoi)
+        private static double PhanTichDiem(string giaTri, string tenMon, string khoi)
         {
             if (string.IsNullOrWhiteSpace(giaTri))
             {
-                throw new FormatException($"Thiếu {tenMon}. {FileStructureGuidance}");
+                throw new FormatException($"Thiếu {tenMon}. {HuongDanCauTrucFile}");
             }
 
             if (double.TryParse(giaTri, NumberStyles.Float, CultureInfo.InvariantCulture, out var diem) ||
@@ -494,13 +494,13 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             {
                 if (diem < 0 || diem > 10)
                 {
-                    throw new FormatException($"{tenMon} cho khối {khoi} phải nằm trong khoảng 0 đến 10. {FileStructureGuidance}");
+                    throw new FormatException($"{tenMon} cho khối {khoi} phải nằm trong khoảng 0 đến 10. {HuongDanCauTrucFile}");
                 }
 
                 return diem;
             }
 
-            throw new FormatException($"Không thể phân tích {tenMon} cho khối {khoi}. {FileStructureGuidance}");
+            throw new FormatException($"Không thể phân tích {tenMon} cho khối {khoi}. {HuongDanCauTrucFile}");
         }
     }
 }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/NgayThangNam.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/NgayThangNam.cs
@@ -10,7 +10,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
         public NgayThangNam(int ngay, int thang, int nam)
         {
-            if (!IsValid(ngay, thang, nam))
+            if (!LaHopLe(ngay, thang, nam))
             {
                 throw new ArgumentOutOfRangeException(nameof(ngay), "Ngày sinh không hợp lệ.");
             }
@@ -25,7 +25,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             return $"{Ngay:D2}/{Thang:D2}/{Nam:D4}";
         }
 
-        private static bool IsValid(int ngay, int thang, int nam)
+        private static bool LaHopLe(int ngay, int thang, int nam)
         {
             if (nam < DateTime.MinValue.Year || nam > DateTime.MaxValue.Year)
             {


### PR DESCRIPTION
## Summary
- đổi tên các phương thức xử lý nhập/xuất điểm và mô tả môn học sang tiếng Việt, bao gồm việc cập nhật lớp cơ sở điểm thi và các lớp kế thừa
- Việt hóa các hàm chuẩn hóa dữ liệu, định dạng điểm và đọc điểm trong bộ quản lý thí sinh, đồng thời cập nhật hằng số hướng dẫn cấu trúc tệp
- đổi tên hàm kiểm tra ngày hợp lệ trong lớp NgayThangNam để thống nhất ngôn ngữ

## Testing
- `dotnet build Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1351d0cb88322b4d92ea4acf89dea