### PR TITLE
Adjust access modifiers to use public and abstract

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiA.cs
@@ -8,7 +8,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public double Ly { get; set; }
         public double Hoa { get; set; }
 
-        protected override MoTaMonHoc[] DanhSachMonHoc
+        public override MoTaMonHoc[] DanhSachMonHoc
         {
             get
             {

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiB.cs
@@ -8,7 +8,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public double Hoa { get; set; }
         public double Sinh { get; set; }
 
-        protected override MoTaMonHoc[] DanhSachMonHoc
+        public override MoTaMonHoc[] DanhSachMonHoc
         {
             get
             {

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemKhoiC.cs
@@ -8,7 +8,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public double Su { get; set; }
         public double Dia { get; set; }
 
-        protected override MoTaMonHoc[] DanhSachMonHoc
+        public override MoTaMonHoc[] DanhSachMonHoc
         {
             get
             {

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBase.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(Diem)DiemThiBase.cs
@@ -4,7 +4,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
     public abstract class DiemThiBase : IDiemThi
     {
-        protected class MoTaMonHoc
+        public class MoTaMonHoc
         {
             public MoTaMonHoc(string tenMon, Func<double> layGiaTri, Action<double> ganGiaTri)
             {
@@ -18,7 +18,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             public Action<double> GanGiaTri { get; }
         }
 
-        protected abstract MoTaMonHoc[] DanhSachMonHoc { get; }
+        public abstract MoTaMonHoc[] DanhSachMonHoc { get; }
 
         public void NhapDiem()
         {
@@ -36,7 +36,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             Console.WriteLine(thongTin);
         }
 
-        protected static double NhapDiemMon(string tenMon)
+        public static double NhapDiemMon(string tenMon)
         {
             double diem;
             Console.Write($"Nhập điểm {tenMon}: ");

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
@@ -21,11 +21,11 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         public int DoiTuongUuTien { get; set; }
         public string HoiDongThi { get; set; }
 
-        protected ThongTinThiSinh()
+        public ThongTinThiSinh()
         {
         }
 
-        protected ThongTinThiSinh(
+        public ThongTinThiSinh(
             string soBD,
             string hoTen,
             NgayThangNam ngaySinh,
@@ -99,7 +99,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             Console.WriteLine("====================================");
         }
 
-        protected double TinhDiemCongKhuVuc()
+        public double TinhDiemCongKhuVuc()
         {
             switch (KhuVuc)
             {
@@ -114,7 +114,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             }
         }
 
-        protected double TinhDiemCongUuTien()
+        public double TinhDiemCongUuTien()
         {
             switch (DoiTuongUuTien)
             {
@@ -127,7 +127,7 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             }
         }
 
-        protected double TinhTongDiemUuTien(double tongDiemBaMon)
+        public double TinhTongDiemUuTien(double tongDiemBaMon)
         {
             var diemUuTienCoBan = TinhDiemCongKhuVuc() + TinhDiemCongUuTien();
             if (diemUuTienCoBan <= 0)

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/NgayThangNam.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/NgayThangNam.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
-    public sealed class NgayThangNam
+    public class NgayThangNam
     {
         public int Ngay { get; }
         public int Thang { get; }

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 {
-    internal class Program
+    public static class Program
     {
         static void Main()
         {


### PR DESCRIPTION
## Summary
- switch the Program entry point to a public static class to avoid internal access
- remove the sealed modifier and protected members so shared abstractions use public access instead

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1ddf1b4548322ba3f59593d9fddb1