### PR TITLE
Validate duplicate candidate IDs during input

### DIFF
--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiA.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiA.cs
@@ -8,10 +8,10 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         {
             Diem = new DiemKhoiA();
         }
-        public void Nhap()
+        public void Nhap(Func<string, bool> kiemTraSoBaoDanhTonTai = null)
         {
             Console.WriteLine("=== Nhập thông tin thí sinh khối A ===");
-            base.NhapThongTin();
+            base.NhapThongTin(kiemTraSoBaoDanhTonTai);
             Diem.NhapDiem();
         }
         public double TinhDiem()

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiB.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiB.cs
@@ -8,10 +8,10 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         {
             Diem = new DiemKhoiB();
         }
-        public void Nhap()
+        public void Nhap(Func<string, bool> kiemTraSoBaoDanhTonTai = null)
         {
             Console.WriteLine("=== Nhập thông tin thí sinh khối B ===");
-            base.NhapThongTin();
+            base.NhapThongTin(kiemTraSoBaoDanhTonTai);
             Diem.NhapDiem();
         }
         public double TinhDiem()

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiC.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TS)ThiSinhKhoiC.cs
@@ -8,10 +8,10 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
         {
             Diem = new DiemKhoiC();
         }
-        public void Nhap()
+        public void Nhap(Func<string, bool> kiemTraSoBaoDanhTonTai = null)
         {
             Console.WriteLine("=== Nhập thông tin thí sinh khối C ===");
-            base.NhapThongTin();
+            base.NhapThongTin(kiemTraSoBaoDanhTonTai);
             Diem.NhapDiem();
         }
         public double TinhDiem()

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/(TT)ThongTinThiSinh.cs
@@ -57,9 +57,9 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             HoiDongThi = hoiDongThi;
         }
 
-        public virtual void NhapThongTin()
+        public virtual void NhapThongTin(Func<string, bool> kiemTraSoBaoDanhTonTai = null)
         {
-            SoBD = NhapChuoiKhongRong("Nhập số báo danh: ");
+            SoBD = NhapSoBaoDanhHopLe(kiemTraSoBaoDanhTonTai);
             HoTen = NhapChuoiKhongRong("Nhập họ và tên: ");
 
             NgaySinh = NhapNgaySinh();
@@ -165,6 +165,22 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
             } while (string.IsNullOrWhiteSpace(ketQua));
 
             return ketQua.Trim();
+        }
+
+        private static string NhapSoBaoDanhHopLe(Func<string, bool> kiemTraSoBaoDanhTonTai)
+        {
+            while (true)
+            {
+                var soBaoDanh = NhapChuoiKhongRong("Nhập số báo danh: ");
+
+                if (kiemTraSoBaoDanhTonTai != null && kiemTraSoBaoDanhTonTai(soBaoDanh))
+                {
+                    Console.WriteLine("Số báo danh đã tồn tại. Vui lòng nhập lại.");
+                    continue;
+                }
+
+                return soBaoDanh;
+            }
         }
 
         private static NgayThangNam NhapNgaySinh()

--- a/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
+++ b/Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học/Program.cs
@@ -206,40 +206,40 @@ namespace Chương_trình_quản_lý_thí_sinh_dự_thi_đại_học
 
         private static void ThemThiSinhKhoiA(QuanLyThiSinh ql, string filePath)
         {
-            ThiSinhKhoiA thiSinh = NhapThiSinhKhoiA();
+            ThiSinhKhoiA thiSinh = NhapThiSinhKhoiA(ql);
             ThemThiSinh(ql, filePath, thiSinh);
         }
 
         private static void ThemThiSinhKhoiB(QuanLyThiSinh ql, string filePath)
         {
-            ThiSinhKhoiB thiSinh = NhapThiSinhKhoiB();
+            ThiSinhKhoiB thiSinh = NhapThiSinhKhoiB(ql);
             ThemThiSinh(ql, filePath, thiSinh);
         }
 
         private static void ThemThiSinhKhoiC(QuanLyThiSinh ql, string filePath)
         {
-            ThiSinhKhoiC thiSinh = NhapThiSinhKhoiC();
+            ThiSinhKhoiC thiSinh = NhapThiSinhKhoiC(ql);
             ThemThiSinh(ql, filePath, thiSinh);
         }
 
-        private static ThiSinhKhoiA NhapThiSinhKhoiA()
+        private static ThiSinhKhoiA NhapThiSinhKhoiA(QuanLyThiSinh ql)
         {
             ThiSinhKhoiA thiSinh = new ThiSinhKhoiA();
-            thiSinh.Nhap();
+            thiSinh.Nhap(soBaoDanh => ql != null && ql.TimTheoSoBD(soBaoDanh) != null);
             return thiSinh;
         }
 
-        private static ThiSinhKhoiB NhapThiSinhKhoiB()
+        private static ThiSinhKhoiB NhapThiSinhKhoiB(QuanLyThiSinh ql)
         {
             ThiSinhKhoiB thiSinh = new ThiSinhKhoiB();
-            thiSinh.Nhap();
+            thiSinh.Nhap(soBaoDanh => ql != null && ql.TimTheoSoBD(soBaoDanh) != null);
             return thiSinh;
         }
 
-        private static ThiSinhKhoiC NhapThiSinhKhoiC()
+        private static ThiSinhKhoiC NhapThiSinhKhoiC(QuanLyThiSinh ql)
         {
             ThiSinhKhoiC thiSinh = new ThiSinhKhoiC();
-            thiSinh.Nhap();
+            thiSinh.Nhap(soBaoDanh => ql != null && ql.TimTheoSoBD(soBaoDanh) != null);
             return thiSinh;
         }
 


### PR DESCRIPTION
## Summary
- validate duplicate candidate IDs while entering new candidate information
- allow candidate data entry to reuse unique-ID checks across all exam blocks
- wire Program.cs to pass the existing candidate lookup when collecting input

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2558b84448322b7060af4a3938e69